### PR TITLE
feat: add tls support for sdg teacher model

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1587,13 +1587,16 @@ deploymentSpec:
           \n            with open(skills_recipe, \"w\", encoding=\"utf-8\") as file:\n\
           \                yaml.dump(skills_yaml, file)\n\n    api_key = getenv(\"\
           api_key\")\n    model = getenv(\"model\")\n    endpoint = getenv(\"endpoint\"\
-          )\n    client = openai.OpenAI(base_url=endpoint, api_key=api_key)\n\n  \
-          \  taxonomy_base = \"main\" if repo_branch or (repo_pr and int(repo_pr)\
-          \ > 0) else \"empty\"\n\n    print(\"Generating synthetic dataset for:\"\
-          )\n    print()\n    print(read_taxonomy(taxonomy_path, taxonomy_base))\n\
-          \n    # Temporary measure to limit the amount of precomputed skills data\
-          \ used to construct the SDG dataset.\n    # Need during development to decrease\
-          \ training loop times and the cost of model quality.\n    set_precomputed_skills_data_ratio(sampling_size=SAMPLING_SIZE)\n\
+          )\n\n    if sdg_ca_cert := getenv(\"SDG_CA_CERT_PATH\"):\n        import\
+          \ httpx\n\n        custom_http_client = httpx.Client(verify=sdg_ca_cert)\n\
+          \        client = openai.OpenAI(\n            base_url=endpoint, api_key=api_key,\
+          \ http_client=custom_http_client\n        )\n    else:\n        client =\
+          \ openai.OpenAI(base_url=endpoint, api_key=api_key)\n\n    taxonomy_base\
+          \ = \"main\" if repo_branch or (repo_pr and int(repo_pr) > 0) else \"empty\"\
+          \n\n    print(\"Generating synthetic dataset for:\")\n    print()\n    print(read_taxonomy(taxonomy_path,\
+          \ taxonomy_base))\n\n    # Temporary measure to limit the amount of precomputed\
+          \ skills data used to construct the SDG dataset.\n    # Need during development\
+          \ to decrease training loop times and the cost of model quality.\n    set_precomputed_skills_data_ratio(sampling_size=SAMPLING_SIZE)\n\
           \n    # generate_data has a magic word for its taxonomy_base argument -\
           \ 'empty'\n    # it allows generating from the whole repo, see:\n    # https://github.com/instructlab/sdg/blob/c6a9e74a1618b1077cd38e713b8aaed8b7c0c8ce/src/instructlab/sdg/utils/taxonomy.py#L230\n\
           \    generate_data(\n        client=client,\n        num_instructions_to_generate=num_instructions_to_generate,\n\

--- a/sdg/components.py
+++ b/sdg/components.py
@@ -59,7 +59,16 @@ def sdg_op(
     api_key = getenv("api_key")
     model = getenv("model")
     endpoint = getenv("endpoint")
-    client = openai.OpenAI(base_url=endpoint, api_key=api_key)
+
+    if sdg_ca_cert := getenv("SDG_CA_CERT_PATH"):
+        import httpx
+
+        custom_http_client = httpx.Client(verify=sdg_ca_cert)
+        client = openai.OpenAI(
+            base_url=endpoint, api_key=api_key, http_client=custom_http_client
+        )
+    else:
+        client = openai.OpenAI(base_url=endpoint, api_key=api_key)
 
     taxonomy_base = "main" if repo_branch or (repo_pr and int(repo_pr) > 0) else "empty"
 

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -400,21 +400,26 @@ evaluation
   true). `SDG_OBJECT_STORE_VERIFY_TLS` environment variable can be used as well. **Optional**
 * `--sdg-object-store-region`: The region of the object store. `SDG_OBJECT_STORE_REGION` environment
   variable can be used as well. **Optional**
-* `--sdg-serving-model-secret`: The name of the Kubernetes secret containing the SDG serving model
+* `--sdg-serving-model-secret`: The name of the Kubernetes Secret containing the SDG serving model
   details. **Optional** - Only valid when running Synthetic Data Generation inside the Kubernetes
   Cluster.
 * `--sdg-serving-model-endpoint`: The endpoint of the SDG serving model. **Optional** - Only valid
   when running Synthetic Data Generation inside the Kubernetes Cluster.
 * `--sdg-serving-model-name`: The name of the model to use for Synthetic Data Generation.
   **Optional**
+* `--sdg-serving-model-ca-cert`: Name of the Kubernetes ConfigMap containing the SDG serving model CA cert.
+  `SDG_SERVING_MODEL_CA_CERT` environment variable can be used as well. **Optional**
+* `--sdg-serving-model-ca-cert-cm-key`: Name of the Key in the Kubernetes ConfigMap containing the SDG serving model CA cert.
+  `SDG_SERVING_MODEL_CA_CERT_CM_KEY` environment variable can be used as well. **Optional**
 * `--sdg-serving-model-api-key`: The API key for the model to use for Synthetic Data Generation. **Optional**
 * `--judge-serving-model-endpoint`: Serving endpoint for evaluation. e.g:
   http://serving.kubeflow.svc.cluster.local:8080/v1 - **Optional**
 * `--judge-serving-model-name`: The name of the model to use for evaluation. **Optional**
 * `--judge-serving-model-api-key`: The API key for the model to evaluate. `JUDGE_SERVING_MODEL_API_KEY`
   environment variable can be used as well. **Optional**
-* `--judge-serving-model-ca-cert`: Name of the Kubernetes ConfigMap containing the serving model CA cert. **Optional**
-* `--judge-serving-model-secret`: The name of the Kubernetes secret containing the judge serving model
+* `--judge-serving-model-ca-cert`: Name of the Kubernetes ConfigMap containing the judge serving model CA cert. **Optional**
+* `--judge-serving-model-ca-cert-cm-key`: Name of the Key in the Kubernetes ConfigMap containing the judge serving model CA cert. **Optional**
+* `--judge-serving-model-secret`: The name of the Kubernetes Secret containing the judge serving model
   API key. **Optional** - If not provided, the script will expect the provided CLI options to evaluate the model.
 * `--force-pull`: Force pull the data (sdg data, model and taxonomy) from the object store even if it already
   exists in the PVC. **Optional** - Default: false.

--- a/standalone/README.md
+++ b/standalone/README.md
@@ -505,15 +505,20 @@ EOF
 > The secret must be part of the same namespace as the resources that the script interacts with.
 > It's inherented from the `--namespace` option.
 
-The list of all supported keys:
+The list of all mandatory keys:
 
 * `bucket`: The bucket name in the object store - **Required**
 * `access_key`: The access key for the object store - **Required**
 * `secret_key`: The secret key for the object store - **Required**
 * `data_key`: The key for the SDG data in the object store - **Required**
+
+Optional keys:
+
 * `verify_tls`: Whether to verify TLS for the object store endpoint (default: true) - **Optional**
 * `endpoint`: The endpoint of the object store, e.g: https://s3.openshift-storage.svc:443 - **Optional**
 * `region`: The region of the object store - **Optional**
+* `SDG_CA_CERT`: The name of ConfigMap containing the custom CA Cert - **Optional**
+* `SDG_CA_CERT_CM_KEY`: The key of the CA Cert in the ConfigMap - **Optional**
 
 A similar operation can be performed for the evaluation judge model serving service. Currently, the script expects the Judge serving service to be running and accessible from within the cluster. If it is not present, the script will not create this resource.
 

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -57,6 +57,9 @@ SDG_OBJECT_STORE_SECRET_NAME = "sdg-object-store-credentials"
 SDG_SERVING_NAME = "sdg-serving-details"
 REPO_GRANITE_7B_IMAGE = "ibm-granite/granite-7b-base"  # used by HF downloader
 SDG_DEFAULT_PIPELINE = "simple"
+SDG_CA_CERT_ENV_VAR_NAME = "SDG_CA_CERT_PATH"
+SDG_CA_CERT_PATH = "/tmp/cert"
+SDG_CA_CERT_CM_KEY = "ca-bundle.crt"
 
 # SDG DATA PREPROCESSING (before doing training, data has to be converted)
 MAX_SEQ_LEN = 4096
@@ -656,14 +659,13 @@ def show(
     "--judge-serving-model-ca-cert",
     type=str,
     help=(
-        "Name of the Kubernetes ConfigMap containing the serving model CA cert."
-        "The expected key name is 'ca-bundle.crt'."
+        "Name of the Kubernetes ConfigMap containing the judge serving model CA cert."
     ),
 )
 @click.option(
     "--judge-serving-model-ca-cert-cm-key",
     type=str,
-    help="Name of the Key in the Kubernetes ConfigMap containing the serving model CA cert.",
+    help="Name of the Key in the Kubernetes ConfigMap containing the judge serving model CA cert.",
     default=JUDGE_CA_CERT_CM_KEY,
 )
 @click.option(
@@ -677,7 +679,8 @@ def show(
         "The following keys are expected: JUDGE_API_KEY, JUDGE_ENDPOINT, JUDGE_NAME"
         "Optional keys are: JUDGE_CA_CERT, JUDGE_CA_CERT_CM_KEY"
         " (JUDGE_SERVING_MODEL_SECRET env var)"
-        "If used, --judge-serving-model-{api-key,endpoint,name,ca-cert} will be ignored."
+        "If used, --judge-serving-model-{api-key,endpoint,name,ca-cert,ca-cert-cm-key} "
+        "options will be ignored."
     ),
 )
 @click.option(
@@ -805,10 +808,24 @@ def show(
         "Name of the Kubernetes Secret containing the sdg serving model endpoint. "
         "For SDG only. "
         "The namespace is inferred from the namespace option. "
-        "The following keys are expected: endpoint, model, api_key "
-        " (SDG_SERVING_MODEL_SECRET env var)"
-        "If used, the --sdg-serving-model-{api-key,endpoint,name} options will be ignored."
+        "The following keys are expected: endpoint, model, api_key, SDG_CA_CERT, "
+        "SDG_CA_CERT_CM_KEY (SDG_SERVING_MODEL_SECRET env var)"
+        "If used, the --sdg-serving-model-{api-key,endpoint,name,ca-cert,ca-cert-cm-key} "
+        "options will be ignored."
     ),
+)
+@click.option(
+    "--sdg-serving-model-ca-cert",
+    type=str,
+    envvar="SDG_SERVING_MODEL_CA_CERT",
+    help=("Name of the Kubernetes ConfigMap containing the SDG serving model CA cert."),
+)
+@click.option(
+    "--sdg-serving-model-ca-cert-cm-key",
+    type=str,
+    envvar="SDG_SERVING_MODEL_CA_CERT_CM_KEY",
+    help="Name of the Key in the Kubernetes ConfigMap containing the SDG serving model CA cert.",
+    default=SDG_CA_CERT_CM_KEY,
 )
 @click.option(
     "--force-pull",
@@ -880,6 +897,8 @@ def run(
     sdg_serving_model_endpoint: typing.Optional[str] = None,
     sdg_serving_model_name: typing.Optional[str] = None,
     sdg_serving_model_api_key: typing.Optional[str] = None,
+    sdg_serving_model_ca_cert: typing.Optional[str] = None,
+    sdg_serving_model_ca_cert_cm_key: typing.Optional[str] = None,
     force_pull: typing.Optional[bool] = False,
     training_1_epoch_num: int = 7,
     training_2_epoch_num: int = 10,
@@ -902,7 +921,7 @@ def run(
         judge_serving_model_api_key (str): The serving model API key for evaluation. For Evaluation
         only.
         judge_serving_model_ca_cert (str): The serving model CA cert for evaluation.
-        judge_serving_model_ca_cert_cm_key (str): The name of the Key in the Kubernetes ConfigMap
+        judge_serving_model_ca_cert_cm_key (str): The name of the Key in the Kubernetes ConfigMap.
         judge_serving_model_secret (str): The name of the Kubernetes Secret containing the serving
         model credentials. For Evaluation only.
         nproc_per_node (int): The number of processes per node. For training only.
@@ -923,6 +942,8 @@ def run(
         sdg_serving_model_endpoint (str): The serving endpoint for SDG.
         sdg_serving_model_name (str): The serving model name for SDG.
         sdg_serving_model_api_key (str): The serving model API key for SDG.
+        sdg_serving_model_ca_cert (str): The serving model CA cert for SDG.
+        sdg_serving_model_ca_cert_cm_key (str): The name of the Key in the Kubernetes ConfigMap.
         force_pull (bool): Force pull the data (sdg data and model) from the object store even if it
         already exists in the PVC.
         training_1_epoch_num (int): Number of epochs to train the model for during phase 1.
@@ -944,8 +965,8 @@ def run(
     ctx.obj["judge_serving_model_name"] = judge_serving_model_name
     ctx.obj["judge_serving_model_api_key"] = judge_serving_model_api_key
     ctx.obj["judge_serving_model_ca_cert"] = judge_serving_model_ca_cert
-    ctx.obj["judge_serving_model_secret"] = judge_serving_model_secret
     ctx.obj["judge_serving_model_ca_cert_cm_key"] = judge_serving_model_ca_cert_cm_key
+    ctx.obj["judge_serving_model_secret"] = judge_serving_model_secret
     ctx.obj["nproc_per_node"] = nproc_per_node
     ctx.obj["eval_type"] = eval_type
     ctx.obj["training_phase"] = training_phase
@@ -962,6 +983,8 @@ def run(
     ctx.obj["sdg_serving_model_endpoint"] = sdg_serving_model_endpoint
     ctx.obj["sdg_serving_model_name"] = sdg_serving_model_name
     ctx.obj["sdg_serving_model_api_key"] = sdg_serving_model_api_key
+    ctx.obj["sdg_serving_model_ca_cert"] = sdg_serving_model_ca_cert
+    ctx.obj["sdg_serving_model_ca_cert_cm_key"] = sdg_serving_model_ca_cert_cm_key
     ctx.obj["force_pull"] = force_pull
     ctx.obj["training_1_epoch_num"] = training_1_epoch_num
     ctx.obj["training_2_epoch_num"] = training_2_epoch_num
@@ -1109,7 +1132,16 @@ def sdg_op(
     api_key = getenv("api_key")
     model = getenv("model")
     endpoint = getenv("endpoint")
-    client = openai.OpenAI(base_url=endpoint, api_key=api_key)
+
+    if sdg_ca_cert := getenv("SDG_CA_CERT_PATH"):
+        import httpx
+
+        custom_http_client = httpx.Client(verify=sdg_ca_cert)
+        client = openai.OpenAI(
+            base_url=endpoint, api_key=api_key, http_client=custom_http_client
+        )
+    else:
+        client = openai.OpenAI(base_url=endpoint, api_key=api_key)
 
     taxonomy_base = "main" if repo_branch or (repo_pr and int(repo_pr) > 0) else "empty"
 
@@ -1174,6 +1206,8 @@ def create_data_job(
     taxonomy_repo_pr: str = "",
     taxonomy_repo_branch: str = "",
     sdg_pipeline: str = SDG_DEFAULT_PIPELINE,
+    sdg_serving_model_ca_cert: str = None,
+    sdg_serving_model_ca_cert_cm_key: str = None,
 ) -> kubernetes.client.V1Job:
     """
     Create a Kubernetes Job object.
@@ -1193,6 +1227,9 @@ def create_data_job(
         the PVC.
         sdg_pipeline (str): The pipeline type used for SDG, value must be 'simple', 'full', or a
         valid path to a directory.
+        sdg_serving_model_ca_cert (str): The serving model CA cert for SDG.
+        sdg_serving_model_ca_cert_cm_key (str): The name of the Key in the Kubernetes ConfigMap.
+
 
     Returns:
         kubernetes.client.V1Job: A Kubernetes Job object configured with the specified parameters.
@@ -1424,15 +1461,42 @@ data_processing_op(max_seq_len={MAX_SEQ_LEN}, max_batch_len={MAX_BATCH_LEN}, sdg
         # If sdg_in_cluster is True, we append the create_sdg_container to the init_containers so
         # the sequence will be: download data (model and taxonomy) -> generate synthetic data
         if sdg_in_cluster:
-            init_containers.append(
-                create_sdg_container(
-                    sdg_serving_model_secret,
-                    num_instructions_to_generate=num_instructions_to_generate,
-                    exec_git_clone_op_repo_branch=taxonomy_repo_branch,
-                    exec_git_clone_op_repo_pr=taxonomy_repo_pr,
-                    sdg_pipeline=sdg_pipeline,
-                )
+            sdg_container = create_sdg_container(
+                sdg_serving_model_secret=sdg_serving_model_secret,
+                num_instructions_to_generate=num_instructions_to_generate,
+                exec_git_clone_op_repo_branch=taxonomy_repo_branch,
+                exec_git_clone_op_repo_pr=taxonomy_repo_pr,
+                sdg_pipeline=sdg_pipeline,
             )
+
+            if sdg_serving_model_ca_cert:
+                # Define the volume that references the ConfigMap
+                cm_volume = kubernetes.client.V1Volume(
+                    name="sdg-ca-cert-volume",
+                    config_map=kubernetes.client.V1ConfigMapVolumeSource(
+                        name=sdg_serving_model_ca_cert
+                    ),
+                )
+                # Define the volume mount to specify where the Secret should be mounted in the container
+                cm_volume_mount = kubernetes.client.V1VolumeMount(
+                    name="sdg-ca-cert-volume",
+                    mount_path=SDG_CA_CERT_PATH,  # Path where the Secret will be mounted
+                )
+                # Add an env var to the container to specify the path to the CA cert
+                sdg_container.env = [
+                    kubernetes.client.V1EnvVar(
+                        name=SDG_CA_CERT_ENV_VAR_NAME,
+                        value=os.path.join(
+                            SDG_CA_CERT_PATH, sdg_serving_model_ca_cert_cm_key
+                        ),
+                    )
+                ]
+                # Add the volume mount to the container
+                sdg_container.volume_mounts.append(cm_volume_mount)
+                # Add the volume to the Pod spec
+                template.spec.volumes.append(cm_volume)
+
+            init_containers.append(sdg_container)
         template.spec.init_containers = init_containers
 
     # Create the specification of deployment
@@ -2297,9 +2361,9 @@ run_final_eval_op(mmlu_branch_output="{MMLU_BRANCH_SCORES_PATH}", mt_bench_branc
                 ),
             )
         ]
-        # Add the volume to the Pod spec
-        eval_container.volume_mounts.append(cm_volume_mount)
         # Add the volume mount to the container
+        eval_container.volume_mounts.append(cm_volume_mount)
+        # Add the volume to the Pod spec
         template.spec.volumes.append(cm_volume)
 
     # Create the specification of deployment
@@ -2824,6 +2888,10 @@ def sdg(
     sdg_serving_model_endpoint = ctx.obj["sdg_serving_model_endpoint"]
     sdg_serving_model_name = ctx.obj["sdg_serving_model_name"]
     sdg_serving_model_api_key = ctx.obj["sdg_serving_model_api_key"]
+
+    sdg_serving_model_ca_cert = ctx.obj["sdg_serving_model_ca_cert"]
+    sdg_serving_model_ca_cert_cm_key = ctx.obj["sdg_serving_model_ca_cert_cm_key"]
+
     num_instructions_to_generate = ctx.obj["num_instructions_to_generate"]
     taxonomy_repo_pr = ctx.obj["taxonomy_repo_pr"]
     taxonomy_repo_branch = ctx.obj["taxonomy_repo_branch"]
@@ -2912,11 +2980,42 @@ def sdg(
                 # Validate the endpoint
                 endpoint = decode_base64(secret.data.get("endpoint"))
                 validate_url(endpoint)
+
+                # Validation of the secret's existence is done in the next conditional block
+                if secret.data.get("SDG_CA_CERT"):
+                    sdg_serving_model_ca_cert = decode_base64(
+                        secret.data.get("SDG_CA_CERT")
+                    )
+                if secret.data.get("SDG_CA_CERT_CM_KEY"):
+                    sdg_serving_model_ca_cert_cm_key = decode_base64(
+                        secret.data.get("SDG_CA_CERT_CM_KEY")
+                    )
             except kubernetes.client.rest.ApiException as exc:
                 if exc.status == 404:
                     raise ValueError(
                         f"Secret {sdg_serving_model_secret} not found in namespace {namespace}."
                     ) from exc
+
+    # If the CA cert is provided, verify the existence of the configmap
+    # We don't add the CA Cert configmap name into the configmap that contains the sdg details
+    # If provided, the configmap will be mounted as a volume in the sdg data job
+    if sdg_serving_model_ca_cert and not dry_run:
+        try:
+            cm = v1.read_namespaced_config_map(
+                name=sdg_serving_model_ca_cert, namespace=namespace
+            )
+            # Validate the presence of the key
+            if not cm.data.get(sdg_serving_model_ca_cert_cm_key):
+                raise ValueError(
+                    f"Provided ConfigMap {sdg_serving_model_ca_cert} does not contain the key:"
+                    f"'{sdg_serving_model_ca_cert_cm_key}'."
+                    "Use '--sdg-serving-model-ca-cert-cm-key' to specify the key."
+                )
+        except kubernetes.client.rest.ApiException as exc:
+            if exc.status == 404:
+                raise ValueError(
+                    f"ConfigMap {sdg_serving_model_ca_cert} not found in namespace {namespace}."
+                ) from exc
 
     logger.info("Initial configuration.")
     initial_setup(ctx)
@@ -2936,6 +3035,8 @@ def sdg(
         taxonomy_repo_pr=taxonomy_repo_pr,
         taxonomy_repo_branch=taxonomy_repo_branch,
         sdg_pipeline=sdg_pipeline,
+        sdg_serving_model_ca_cert=sdg_serving_model_ca_cert,
+        sdg_serving_model_ca_cert_cm_key=sdg_serving_model_ca_cert_cm_key,
     )
 
     if dry_run:


### PR DESCRIPTION
Adds tls support for SDG teacher model. 

Implementation is very similar to how certs are passed in for the judge server model. Note that each model can be served in different locations/clusters, so we require configurable bundles for each (i.e. they can't share it). 
