### PR TITLE
feat: rename and document pipeline parameters

### DIFF
--- a/eval/final/components.py
+++ b/eval/final/components.py
@@ -15,8 +15,6 @@ def run_final_eval_op(
     base_branch: str,
     candidate_branch: str,
     max_workers: str,
-    device: str,
-    model_dtype: str,
     few_shots: int,
     batch_size: str,
     merge_system_user_message: bool,

--- a/eval/mt_bench/components.py
+++ b/eval/mt_bench/components.py
@@ -18,7 +18,6 @@ def run_mt_bench_op(
     output_path: str = "/output/mt_bench_data.json",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
-    device: str = None,
     best_score_file: Optional[str] = None,
 ) -> NamedTuple("outputs", best_model=str, best_score=float):
     import json

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2,32 +2,33 @@
 # Name: instructlab
 # Description: InstructLab pipeline
 # Inputs:
-#    base_model: str [Default: 'ibm-granite/granite-7b-base']
-#    batch_size: str [Default: 'auto']
-#    device: str
-#    effective_batch_size_phase_1: int [Default: 3840.0]
-#    effective_batch_size_phase_2: int [Default: 3840.0]
-#    few_shots: int [Default: 5.0]
-#    learning_rate_phase_1: float [Default: 0.0001]
-#    learning_rate_phase_2: float [Default: 0.0001]
-#    max_batch_len: int [Default: 20000.0]
-#    max_workers: str [Default: 'auto']
-#    merge_system_user_message: bool [Default: False]
-#    model_dtype: str [Default: 'bfloat16']
-#    nnodes: int [Default: 2.0]
-#    nproc_per_node: int [Default: 3.0]
-#    num_epochs_phase_1: int [Default: 2.0]
-#    num_epochs_phase_2: int [Default: 2.0]
-#    num_instructions_to_generate: int [Default: 2.0]
-#    num_warmup_steps_phase_1: int [Default: 100.0]
-#    num_warmup_steps_phase_2: int [Default: 100.0]
-#    repo_branch: str
-#    repo_pr: int
-#    repo_url: str [Default: 'https://github.com/instructlab/taxonomy.git']
-#    save_samples: int [Default: 0.0]
+#    final_eval_batch_size: str [Default: 'auto']
+#    final_eval_few_shots: int [Default: 5.0]
+#    final_eval_max_workers: str [Default: 'auto']
+#    final_eval_merge_system_user_message: bool [Default: False]
+#    k8s_storage_class_name: str [Default: 'nfs-csi']
+#    mt_bench_max_workers: str [Default: 'auto']
+#    mt_bench_merge_system_user_message: bool [Default: False]
+#    sdg_base_model: str [Default: 'ibm-granite/granite-7b-base']
+#    sdg_max_batch_len: int [Default: 20000.0]
 #    sdg_pipeline: str [Default: 'simple']
-#    seed: int [Default: 42.0]
-#    storage_class_name: str [Default: 'nfs-csi']
+#    sdg_repo_branch: str
+#    sdg_repo_pr: int
+#    sdg_repo_url: str [Default: 'https://github.com/instructlab/taxonomy.git']
+#    sdg_scale_factor: int [Default: 2.0]
+#    train_effective_batch_size_phase_1: int [Default: 3840.0]
+#    train_effective_batch_size_phase_2: int [Default: 3840.0]
+#    train_learning_rate_phase_1: float [Default: 0.0001]
+#    train_learning_rate_phase_2: float [Default: 0.0001]
+#    train_max_batch_len: int [Default: 20000.0]
+#    train_nnodes: int [Default: 2.0]
+#    train_nproc_per_node: int [Default: 3.0]
+#    train_num_epochs_phase_1: int [Default: 2.0]
+#    train_num_epochs_phase_2: int [Default: 2.0]
+#    train_num_warmup_steps_phase_1: int [Default: 100.0]
+#    train_num_warmup_steps_phase_2: int [Default: 100.0]
+#    train_save_samples: int [Default: 0.0]
+#    train_seed: int [Default: 42.0]
 components:
   comp-createpvc:
     executorLabel: exec-createpvc
@@ -495,16 +496,12 @@ components:
         candidate_model:
           isOptional: true
           parameterType: STRING
-        device:
-          parameterType: STRING
         few_shots:
           parameterType: NUMBER_INTEGER
         max_workers:
           parameterType: STRING
         merge_system_user_message:
           parameterType: BOOLEAN
-        model_dtype:
-          parameterType: STRING
         sdg_path:
           defaultValue: /input/sdg
           isOptional: true
@@ -528,9 +525,6 @@ components:
     inputDefinitions:
       parameters:
         best_score_file:
-          isOptional: true
-          parameterType: STRING
-        device:
           isOptional: true
           parameterType: STRING
         max_workers:
@@ -1177,28 +1171,28 @@ deploymentSpec:
           \ *\n\ndef run_final_eval_op(\n    mmlu_branch_output: Output[Artifact],\n\
           \    mt_bench_branch_output: Output[Artifact],\n    base_model_dir: str,\n\
           \    base_branch: str,\n    candidate_branch: str,\n    max_workers: str,\n\
-          \    device: str,\n    model_dtype: str,\n    few_shots: int,\n    batch_size:\
-          \ str,\n    merge_system_user_message: bool,\n    candidate_model: str =\
-          \ None,\n    taxonomy_path: str = \"/input/taxonomy\",\n    sdg_path: str\
-          \ = \"/input/sdg\",\n):\n    import json\n    import os\n    import subprocess\n\
-          \n    import torch\n    from instructlab.eval.mmlu import MMLU_TASKS, MMLUBranchEvaluator\n\
-          \    from instructlab.eval.mt_bench import MTBenchBranchEvaluator\n    from\
-          \ instructlab.model.evaluate import qa_pairs_to_qna_to_avg_scores, sort_score\n\
-          \n    if judge_ca_cert := os.getenv(\"JUDGE_CA_CERT_PATH\"):\n        import\
-          \ httpx\n        import openai\n\n        # Create a custom HTTP client\n\
-          \        class CustomHttpClient(httpx.Client):\n            def __init__(self,\
-          \ *args, **kwargs):\n                # Use the custom CA certificate\n \
-          \               kwargs.setdefault(\"verify\", judge_ca_cert)\n         \
-          \       super().__init__(*args, **kwargs)\n\n        # Create a new OpenAI\
-          \ class that uses the custom HTTP client\n        class CustomOpenAI(openai.OpenAI):\n\
-          \            def __init__(self, *args, **kwargs):\n                custom_client\
-          \ = CustomHttpClient()\n                super().__init__(http_client=custom_client,\
-          \ *args, **kwargs)\n\n        # Monkey patch the OpenAI class in the openai\
-          \ module, so that the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\
-          \n    print(\"Starting Final Eval...\")\n\n    def launch_vllm(\n      \
-          \  model_path: str, gpu_count: int, retries: int = 120, delay: int = 10\n\
-          \    ) -> tuple:\n        import subprocess\n        import sys\n      \
-          \  import time\n\n        import requests\n        from instructlab.model.backends.common\
+          \    few_shots: int,\n    batch_size: str,\n    merge_system_user_message:\
+          \ bool,\n    candidate_model: str = None,\n    taxonomy_path: str = \"/input/taxonomy\"\
+          ,\n    sdg_path: str = \"/input/sdg\",\n):\n    import json\n    import\
+          \ os\n    import subprocess\n\n    import torch\n    from instructlab.eval.mmlu\
+          \ import MMLU_TASKS, MMLUBranchEvaluator\n    from instructlab.eval.mt_bench\
+          \ import MTBenchBranchEvaluator\n    from instructlab.model.evaluate import\
+          \ qa_pairs_to_qna_to_avg_scores, sort_score\n\n    if judge_ca_cert := os.getenv(\"\
+          JUDGE_CA_CERT_PATH\"):\n        import httpx\n        import openai\n\n\
+          \        # Create a custom HTTP client\n        class CustomHttpClient(httpx.Client):\n\
+          \            def __init__(self, *args, **kwargs):\n                # Use\
+          \ the custom CA certificate\n                kwargs.setdefault(\"verify\"\
+          , judge_ca_cert)\n                super().__init__(*args, **kwargs)\n\n\
+          \        # Create a new OpenAI class that uses the custom HTTP client\n\
+          \        class CustomOpenAI(openai.OpenAI):\n            def __init__(self,\
+          \ *args, **kwargs):\n                custom_client = CustomHttpClient()\n\
+          \                super().__init__(http_client=custom_client, *args, **kwargs)\n\
+          \n        # Monkey patch the OpenAI class in the openai module, so that\
+          \ the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\n    print(\"\
+          Starting Final Eval...\")\n\n    def launch_vllm(\n        model_path: str,\
+          \ gpu_count: int, retries: int = 120, delay: int = 10\n    ) -> tuple:\n\
+          \        import subprocess\n        import sys\n        import time\n\n\
+          \        import requests\n        from instructlab.model.backends.common\
           \ import free_tcp_ipv4_port\n\n        free_port = free_tcp_ipv4_port(\"\
           127.0.0.1\")\n        port = str(free_port)\n        vllm_server = f\"http://127.0.0.1:{port}/v1\"\
           \n\n        command = [\n            sys.executable,\n            \"-m\"\
@@ -1445,41 +1439,40 @@ deploymentSpec:
           \ is calculated based on environment\n    # https://github.com/instructlab/eval/blob/main/src/instructlab/eval/mt_bench.py#L36\n\
           \    max_workers: str,\n    output_path: str = \"/output/mt_bench_data.json\"\
           ,\n    models_list: List[str] = None,\n    models_folder: Optional[str]\
-          \ = None,\n    device: str = None,\n    best_score_file: Optional[str] =\
-          \ None,\n) -> NamedTuple(\"outputs\", best_model=str, best_score=float):\n\
-          \    import json\n    import os\n    import subprocess\n\n    import torch\n\
-          \    from instructlab.eval.mt_bench import MTBenchEvaluator\n\n    if judge_ca_cert\
-          \ := os.getenv(\"JUDGE_CA_CERT_PATH\"):\n        import httpx\n        import\
-          \ openai\n\n        # Create a custom HTTP client\n        class CustomHttpClient(httpx.Client):\n\
-          \            def __init__(self, *args, **kwargs):\n                # Use\
-          \ the custom CA certificate\n                kwargs.setdefault(\"verify\"\
-          , judge_ca_cert)\n                super().__init__(*args, **kwargs)\n\n\
-          \        # Create a new OpenAI class that uses the custom HTTP client\n\
-          \        class CustomOpenAI(openai.OpenAI):\n            def __init__(self,\
-          \ *args, **kwargs):\n                custom_client = CustomHttpClient()\n\
-          \                super().__init__(http_client=custom_client, *args, **kwargs)\n\
-          \n        # Monkey patch the OpenAI class in the openai module, so that\
-          \ the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\n    def\
-          \ launch_vllm(\n        model_path: str, gpu_count: int, retries: int =\
-          \ 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n   \
-          \     import sys\n        import time\n\n        import requests\n     \
-          \   from instructlab.model.backends.common import free_tcp_ipv4_port\n\n\
-          \        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port = str(free_port)\n\
-          \        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\n        command\
-          \ = [\n            sys.executable,\n            \"-m\",\n            \"\
-          vllm.entrypoints.openai.api_server\",\n            \"--port\",\n       \
-          \     port,\n            \"--model\",\n            model_path,\n       \
-          \ ]\n        if gpu_count > 0:\n            command += [\n             \
-          \   \"--tensor-parallel-size\",\n                str(gpu_count),\n     \
-          \       ]\n\n        process = subprocess.Popen(args=command)\n\n      \
-          \  print(f\"Waiting for vLLM server to start at {vllm_server}...\")\n\n\
-          \        for attempt in range(retries):\n            try:\n            \
-          \    response = requests.get(f\"{vllm_server}/models\")\n              \
-          \  if response.status_code == 200:\n                    print(f\"vLLM server\
-          \ is up and running at {vllm_server}.\")\n                    return process,\
-          \ vllm_server\n            except requests.ConnectionError:\n          \
-          \      pass\n\n            print(\n                f\"Server not available\
-          \ yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
+          \ = None,\n    best_score_file: Optional[str] = None,\n) -> NamedTuple(\"\
+          outputs\", best_model=str, best_score=float):\n    import json\n    import\
+          \ os\n    import subprocess\n\n    import torch\n    from instructlab.eval.mt_bench\
+          \ import MTBenchEvaluator\n\n    if judge_ca_cert := os.getenv(\"JUDGE_CA_CERT_PATH\"\
+          ):\n        import httpx\n        import openai\n\n        # Create a custom\
+          \ HTTP client\n        class CustomHttpClient(httpx.Client):\n         \
+          \   def __init__(self, *args, **kwargs):\n                # Use the custom\
+          \ CA certificate\n                kwargs.setdefault(\"verify\", judge_ca_cert)\n\
+          \                super().__init__(*args, **kwargs)\n\n        # Create a\
+          \ new OpenAI class that uses the custom HTTP client\n        class CustomOpenAI(openai.OpenAI):\n\
+          \            def __init__(self, *args, **kwargs):\n                custom_client\
+          \ = CustomHttpClient()\n                super().__init__(http_client=custom_client,\
+          \ *args, **kwargs)\n\n        # Monkey patch the OpenAI class in the openai\
+          \ module, so that the eval lib can use it\n        openai.OpenAI = CustomOpenAI\n\
+          \n    def launch_vllm(\n        model_path: str, gpu_count: int, retries:\
+          \ int = 120, delay: int = 10\n    ) -> tuple:\n        import subprocess\n\
+          \        import sys\n        import time\n\n        import requests\n  \
+          \      from instructlab.model.backends.common import free_tcp_ipv4_port\n\
+          \n        free_port = free_tcp_ipv4_port(\"127.0.0.1\")\n        port =\
+          \ str(free_port)\n        vllm_server = f\"http://127.0.0.1:{port}/v1\"\n\
+          \n        command = [\n            sys.executable,\n            \"-m\",\n\
+          \            \"vllm.entrypoints.openai.api_server\",\n            \"--port\"\
+          ,\n            port,\n            \"--model\",\n            model_path,\n\
+          \        ]\n        if gpu_count > 0:\n            command += [\n      \
+          \          \"--tensor-parallel-size\",\n                str(gpu_count),\n\
+          \            ]\n\n        process = subprocess.Popen(args=command)\n\n \
+          \       print(f\"Waiting for vLLM server to start at {vllm_server}...\"\
+          )\n\n        for attempt in range(retries):\n            try:\n        \
+          \        response = requests.get(f\"{vllm_server}/models\")\n          \
+          \      if response.status_code == 200:\n                    print(f\"vLLM\
+          \ server is up and running at {vllm_server}.\")\n                    return\
+          \ process, vllm_server\n            except requests.ConnectionError:\n \
+          \               pass\n\n            print(\n                f\"Server not\
+          \ available yet, retrying in {delay} seconds (Attempt {attempt + 1}/{retries})...\"\
           \n            )\n            time.sleep(delay)\n\n        raise RuntimeError(\n\
           \            f\"Failed to start vLLM server at {vllm_server} after {retries}\
           \ retries.\"\n        )\n\n    def shutdown_vllm(process: subprocess.Popen,\
@@ -1661,7 +1654,7 @@ root:
               runtimeValue:
                 constant: 10Gi
             storage_class_name:
-              componentInputParameter: storage_class_name
+              componentInputParameter: k8s_storage_class_name
         taskInfo:
           name: createpvc
       createpvc-2:
@@ -1682,7 +1675,7 @@ root:
               runtimeValue:
                 constant: 100Gi
             storage_class_name:
-              componentInputParameter: storage_class_name
+              componentInputParameter: k8s_storage_class_name
         taskInfo:
           name: createpvc-2
       createpvc-3:
@@ -1703,7 +1696,7 @@ root:
               runtimeValue:
                 constant: 100Gi
             storage_class_name:
-              componentInputParameter: storage_class_name
+              componentInputParameter: k8s_storage_class_name
         taskInfo:
           name: createpvc-3
       data-processing-op:
@@ -1715,6 +1708,10 @@ root:
         - createpvc-2
         - huggingface-importer-op
         - sdg-op
+        inputs:
+          parameters:
+            max_batch_len:
+              componentInputParameter: sdg_max_batch_len
         taskInfo:
           name: data-processing-op
       deletepvc:
@@ -1776,11 +1773,11 @@ root:
         inputs:
           parameters:
             repo_branch:
-              componentInputParameter: repo_branch
+              componentInputParameter: sdg_repo_branch
             repo_pr:
-              componentInputParameter: repo_pr
+              componentInputParameter: sdg_repo_pr
             repo_url:
-              componentInputParameter: repo_url
+              componentInputParameter: sdg_repo_url
         taskInfo:
           name: git-clone-op
       huggingface-importer-op:
@@ -1792,7 +1789,7 @@ root:
         inputs:
           parameters:
             repo_name:
-              componentInputParameter: base_model
+              componentInputParameter: sdg_base_model
         taskInfo:
           name: huggingface-importer-op
       knowledge-processed-data-to-artifact-op:
@@ -1930,15 +1927,15 @@ root:
         inputs:
           parameters:
             effective_batch_size:
-              componentInputParameter: effective_batch_size_phase_1
+              componentInputParameter: train_effective_batch_size_phase_1
             input_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc
             learning_rate:
-              componentInputParameter: learning_rate_phase_1
+              componentInputParameter: train_learning_rate_phase_1
             max_batch_len:
-              componentInputParameter: max_batch_len
+              componentInputParameter: train_max_batch_len
             model_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
@@ -1948,13 +1945,13 @@ root:
                 outputParameterKey: name
                 producerTask: createpvc
             nnodes:
-              componentInputParameter: nnodes
+              componentInputParameter: train_nnodes
             nproc_per_node:
-              componentInputParameter: nproc_per_node
+              componentInputParameter: train_nproc_per_node
             num_epochs:
-              componentInputParameter: num_epochs_phase_1
+              componentInputParameter: train_num_epochs_phase_1
             num_warmup_steps:
-              componentInputParameter: num_warmup_steps_phase_1
+              componentInputParameter: train_num_warmup_steps_phase_1
             output_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
@@ -1963,9 +1960,9 @@ root:
               runtimeValue:
                 constant: 1.0
             save_samples:
-              componentInputParameter: save_samples
+              componentInputParameter: train_save_samples
             seed:
-              componentInputParameter: seed
+              componentInputParameter: train_seed
         taskInfo:
           name: pytorchjob-manifest-op
       pytorchjob-manifest-op-2:
@@ -1980,15 +1977,15 @@ root:
         inputs:
           parameters:
             effective_batch_size:
-              componentInputParameter: effective_batch_size_phase_2
+              componentInputParameter: train_effective_batch_size_phase_2
             input_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
                 producerTask: createpvc
             learning_rate:
-              componentInputParameter: learning_rate_phase_2
+              componentInputParameter: train_learning_rate_phase_2
             max_batch_len:
-              componentInputParameter: max_batch_len
+              componentInputParameter: train_max_batch_len
             model_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
@@ -1998,13 +1995,13 @@ root:
                 outputParameterKey: name
                 producerTask: createpvc
             nnodes:
-              componentInputParameter: nnodes
+              componentInputParameter: train_nnodes
             nproc_per_node:
-              componentInputParameter: nproc_per_node
+              componentInputParameter: train_nproc_per_node
             num_epochs:
-              componentInputParameter: num_epochs_phase_2
+              componentInputParameter: train_num_epochs_phase_2
             num_warmup_steps:
-              componentInputParameter: num_warmup_steps_phase_2
+              componentInputParameter: train_num_warmup_steps_phase_2
             output_pvc_name:
               taskOutputParameter:
                 outputParameterKey: name
@@ -2013,9 +2010,9 @@ root:
               runtimeValue:
                 constant: 2.0
             save_samples:
-              componentInputParameter: save_samples
+              componentInputParameter: train_save_samples
             seed:
-              componentInputParameter: seed
+              componentInputParameter: train_seed
         taskInfo:
           name: pytorchjob-manifest-op-2
       run-final-eval-op:
@@ -2031,27 +2028,23 @@ root:
         inputs:
           parameters:
             base_branch:
-              componentInputParameter: repo_branch
+              componentInputParameter: sdg_repo_branch
             base_model_dir:
               runtimeValue:
                 constant: /model/
             batch_size:
-              componentInputParameter: batch_size
+              componentInputParameter: final_eval_batch_size
             candidate_branch:
-              componentInputParameter: repo_branch
+              componentInputParameter: sdg_repo_branch
             candidate_model:
               runtimeValue:
                 constant: /output/phase_2/model/hf_format/candidate_model
-            device:
-              componentInputParameter: device
             few_shots:
-              componentInputParameter: few_shots
+              componentInputParameter: final_eval_few_shots
             max_workers:
-              componentInputParameter: max_workers
+              componentInputParameter: final_eval_max_workers
             merge_system_user_message:
-              componentInputParameter: merge_system_user_message
-            model_dtype:
-              componentInputParameter: model_dtype
+              componentInputParameter: final_eval_merge_system_user_message
         taskInfo:
           name: run-final-eval-op
       run-mt-bench-op:
@@ -2063,12 +2056,10 @@ root:
         - list-models-in-directory-op
         inputs:
           parameters:
-            device:
-              componentInputParameter: device
             max_workers:
-              componentInputParameter: max_workers
+              componentInputParameter: mt_bench_max_workers
             merge_system_user_message:
-              componentInputParameter: merge_system_user_message
+              componentInputParameter: mt_bench_merge_system_user_message
             models_list:
               taskOutputParameter:
                 outputParameterKey: Output
@@ -2088,13 +2079,13 @@ root:
         inputs:
           parameters:
             num_instructions_to_generate:
-              componentInputParameter: num_instructions_to_generate
+              componentInputParameter: sdg_scale_factor
             pipeline:
               componentInputParameter: sdg_pipeline
             repo_branch:
-              componentInputParameter: repo_branch
+              componentInputParameter: sdg_repo_branch
             repo_pr:
-              componentInputParameter: repo_pr
+              componentInputParameter: sdg_repo_pr
         taskInfo:
           name: sdg-op
       sdg-to-artifact-op:
@@ -2130,107 +2121,169 @@ root:
           name: taxonomy-to-artifact-op
   inputDefinitions:
     parameters:
-      base_model:
-        defaultValue: ibm-granite/granite-7b-base
-        isOptional: true
-        parameterType: STRING
-      batch_size:
+      final_eval_batch_size:
         defaultValue: auto
+        description: Final model evaluation parameter for MMLU. Batch size for evaluation.
+          Valid values are a positive integer or 'auto' to select the largest batch
+          size that will fit in memory.
         isOptional: true
         parameterType: STRING
-      device:
-        isOptional: true
-        parameterType: STRING
-      effective_batch_size_phase_1:
-        defaultValue: 3840.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      effective_batch_size_phase_2:
-        defaultValue: 3840.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      few_shots:
+      final_eval_few_shots:
         defaultValue: 5.0
+        description: Final model evaluation parameter for MMLU. Number of question-answer
+          pairs provided in the context preceding the question used for evaluation.
         isOptional: true
         parameterType: NUMBER_INTEGER
-      learning_rate_phase_1:
-        defaultValue: 0.0001
-        isOptional: true
-        parameterType: NUMBER_DOUBLE
-      learning_rate_phase_2:
-        defaultValue: 0.0001
-        isOptional: true
-        parameterType: NUMBER_DOUBLE
-      max_batch_len:
-        defaultValue: 20000.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      max_workers:
+      final_eval_max_workers:
         defaultValue: auto
+        description: Final model evaluation parameter for MT Bench Branch. Number
+          of workers to use for evaluation with mt_bench or mt_bench_branch. Must
+          be a positive integer or 'auto'.
         isOptional: true
         parameterType: STRING
-      merge_system_user_message:
+      final_eval_merge_system_user_message:
         defaultValue: false
+        description: Final model evaluation parameter for MT Bench Branch. Boolean
+          indicating whether to merge system and user messages (required for Mistral
+          based judges)
         isOptional: true
         parameterType: BOOLEAN
-      model_dtype:
-        defaultValue: bfloat16
+      k8s_storage_class_name:
+        defaultValue: nfs-csi
+        description: A Kubernetes StorageClass name for persistent volumes. Selected
+          StorageClass must support RWX PersistentVolumes.
         isOptional: true
         parameterType: STRING
-      nnodes:
-        defaultValue: 2.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      nproc_per_node:
-        defaultValue: 3.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      num_epochs_phase_1:
-        defaultValue: 2.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      num_epochs_phase_2:
-        defaultValue: 2.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      num_instructions_to_generate:
-        defaultValue: 2.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      num_warmup_steps_phase_1:
-        defaultValue: 100.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      num_warmup_steps_phase_2:
-        defaultValue: 100.0
-        isOptional: true
-        parameterType: NUMBER_INTEGER
-      repo_branch:
+      mt_bench_max_workers:
+        defaultValue: auto
+        description: MT Bench parameter. Number of workers to use for evaluation with
+          mt_bench or mt_bench_branch. Must be a positive integer or 'auto'.
         isOptional: true
         parameterType: STRING
-      repo_pr:
+      mt_bench_merge_system_user_message:
+        defaultValue: false
+        description: MT Bench parameter. Boolean indicating whether to merge system
+          and user messages (required for Mistral based judges)
         isOptional: true
-        parameterType: NUMBER_INTEGER
-      repo_url:
-        defaultValue: https://github.com/instructlab/taxonomy.git
+        parameterType: BOOLEAN
+      sdg_base_model:
+        defaultValue: ibm-granite/granite-7b-base
+        description: SDG parameter. LLM model used to generate the synthetic dataset
         isOptional: true
         parameterType: STRING
-      save_samples:
-        defaultValue: 0.0
+      sdg_max_batch_len:
+        defaultValue: 20000.0
+        description: SDG parameter. Maximum tokens per gpu for each batch that will
+          be handled in a single step.
         isOptional: true
         parameterType: NUMBER_INTEGER
       sdg_pipeline:
         defaultValue: simple
+        description: 'SDG parameter. Data generation pipeline to use. Available: ''simple'',
+          ''full'', or a valid path to a directory of pipeline workflow YAML files.
+          Note that ''full'' requires a larger teacher model, Mixtral-8x7b.'
         isOptional: true
         parameterType: STRING
-      seed:
-        defaultValue: 42.0
+      sdg_repo_branch:
+        description: SDG parameter. Points to a branch within the taxonomy git repository.
+          If set, has priority over sdg_repo_pr
+        isOptional: true
+        parameterType: STRING
+      sdg_repo_pr:
+        description: SDG parameter. Points to a pull request against the taxonomy
+          git repository
         isOptional: true
         parameterType: NUMBER_INTEGER
-      storage_class_name:
-        defaultValue: nfs-csi
+      sdg_repo_url:
+        defaultValue: https://github.com/instructlab/taxonomy.git
+        description: SDG parameter. Points to a taxonomy git repository
         isOptional: true
         parameterType: STRING
+      sdg_scale_factor:
+        defaultValue: 2.0
+        description: SDG parameter. The total number of instructions to be generated.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_effective_batch_size_phase_1:
+        defaultValue: 3840.0
+        description: Training parameter for in Phase 1. The number of samples in a
+          batch that the model should see before its parameters are updated.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_effective_batch_size_phase_2:
+        defaultValue: 3840.0
+        description: Training parameter for in Phase 2. The number of samples in a
+          batch that the model should see before its parameters are updated.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_learning_rate_phase_1:
+        defaultValue: 0.0001
+        description: Training parameter for in Phase 1. How fast we optimize the weights
+          during gradient descent. Higher values may lead to unstable learning performance.
+          It's generally recommended to have a low learning rate with a high effective
+          batch size.
+        isOptional: true
+        parameterType: NUMBER_DOUBLE
+      train_learning_rate_phase_2:
+        defaultValue: 0.0001
+        description: Training parameter for in Phase 2. How fast we optimize the weights
+          during gradient descent. Higher values may lead to unstable learning performance.
+          It's generally recommended to have a low learning rate with a high effective
+          batch size.
+        isOptional: true
+        parameterType: NUMBER_DOUBLE
+      train_max_batch_len:
+        defaultValue: 20000.0
+        description: Training parameter. Maximum tokens per gpu for each batch that
+          will be handled in a single step.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_nnodes:
+        defaultValue: 2.0
+        description: Training parameter. Number of nodes/workers to train on.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_nproc_per_node:
+        defaultValue: 3.0
+        description: Training parameter. Number of GPUs per each node/worker to use
+          for training.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_num_epochs_phase_1:
+        defaultValue: 2.0
+        description: Training parameter for in Phase 1. Number of epochs to run training.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_num_epochs_phase_2:
+        defaultValue: 2.0
+        description: Training parameter for in Phase 2. Number of epochs to run training.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_num_warmup_steps_phase_1:
+        defaultValue: 100.0
+        description: Training parameter for in Phase 1. The number of steps a model
+          should go through before reaching the full learning rate. We start at 0
+          and linearly climb up to train_learning_rate.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_num_warmup_steps_phase_2:
+        defaultValue: 100.0
+        description: Training parameter for in Phase 2. The number of steps a model
+          should go through before reaching the full learning rate. We start at 0
+          and linearly climb up to train_learning_rate.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_save_samples:
+        defaultValue: 0.0
+        description: Training parameter. Number of samples the model should see before
+          saving a checkpoint.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+      train_seed:
+        defaultValue: 42.0
+        description: Training parameter. Random seed for initializing training.
+        isOptional: true
+        parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
 sdkVersion: kfp-2.10.1
 ---

--- a/standalone/standalone.py
+++ b/standalone/standalone.py
@@ -1515,7 +1515,6 @@ def run_mt_bench_op(
     output_path: str = "/output/mt_bench_data.json",
     models_list: List[str] = None,
     models_folder: Optional[str] = None,
-    device: str = None,
     best_score_file: Optional[str] = None,
 ) -> NamedTuple("outputs", best_model=str, best_score=float):
     import json
@@ -1735,8 +1734,6 @@ def run_final_eval_op(
     base_branch: str,
     candidate_branch: str,
     max_workers: str,
-    device: str,
-    model_dtype: str,
     few_shots: int,
     batch_size: str,
     merge_system_user_message: bool,


### PR DESCRIPTION
Work in progress at the moment...

## Description
Resolves https://github.com/opendatahub-io/ilab-on-ocp/issues/125


1. Some params are renamed to align the pipeline with upstream InstructLab CLI.
2. Some params are cleaned up since they are not used at all.

Descriptions sourced mostly from:
- https://github.com/instructlab/instructlab/blob/fa5d1cc7df986b418112484c033a70b9a35a02c3/src/instructlab/configuration.py
- https://github.com/instructlab/eval/blob/f4db222e45f85add39f3b64571b27fb009ff4092/src/instructlab/eval/mt_bench.py#L177

## Known issues

RHOAI does not maintain param order defined in DSL, therefore in the UI params are ordered alphabetically. This means we'll get them in following order: `eval_*`, `mt_bench_*`, `sdg_*`, `train_*`. Not sure if this is what we want, but unless we rename them, there's nothing we can do. 

Result:

https://github.com/user-attachments/assets/527ec663-f08a-450c-8382-80beec524f6d


