### PR TITLE
add image_pull_secrets to data processing op

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -230,6 +230,8 @@ def pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
         data_processing_task.after(model_to_pvc_task, sdg_task)
         data_processing_task.set_caching_options(False)
 
+        set_image_pull_secrets(data_processing_task, [IMAGE_PULL_SECRET])
+
         # Upload "skills_processed_data" and "knowledge_processed_data" artifacts to S3 without blocking the rest of the workflow
         skills_processed_data_to_artifact_task = skills_processed_data_to_artifact_op()
         skills_processed_data_to_artifact_task.after(data_processing_task)

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2220,6 +2220,8 @@ platforms:
     deploymentSpec:
       executors:
         exec-data-processing-op:
+          imagePullSecret:
+          - secretName: redhat-et-ilab-botty-pull-secret
           pvcMount:
           - mountPath: /model
             taskOutputParameter:


### PR DESCRIPTION
Related to #183 and #182 

Need to add `set_image_pull_secrets()` to `data_processing_task()` so that it can use the correct image. 
