### PR TITLE
set install_kfp_package=False for data_processing_op

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -631,13 +631,6 @@ deploymentSpec:
         - data_processing_op
         command:
         - sh
-        - -c
-        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
-          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.10.1'\
-          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
-          $0\" \"$@\"\n"
-        - sh
         - -ec
         - 'program_path=$(mktemp -d)
 

--- a/training/components.py
+++ b/training/components.py
@@ -8,7 +8,7 @@ from kfp import dsl
 from utils.consts import PYTHON_IMAGE, RHELAI_IMAGE, TOOLBOX_IMAGE
 
 
-@dsl.component(base_image=RHELAI_IMAGE)
+@dsl.component(base_image=RHELAI_IMAGE, install_kfp_package=False)
 def data_processing_op(
     model_path: str = "/model",
     sdg_path: str = "/data/sdg",


### PR DESCRIPTION
This PR sets the `install_kfp_package` to `False` for the `data_processing_op`. Without this setting the `data_processing_op` will throw the following error:
`ERROR: Could not install packages due to an OSError: [Errno 13] Permission denied: '/opt/app-root/bin/dsl-compile`