### PR TITLE
fix: update image in standalone.tpl instead of standalone.py

### DIFF
--- a/standalone/standalone.tpl
+++ b/standalone/standalone.tpl
@@ -49,7 +49,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 # IMAGES
-DS_IMAGE = "quay.io/opendatahub/workbench-images@sha256:7f26f5f2bec4184af15acd95f29b3450526c5c28c386b6cb694fbe82d71d0b41"  # pylint: disable=line-too-long
+DS_IMAGE = "quay.io/modh/odh-generic-data-science-notebook@sha256:7c1a4ca213b71d342a2d1366171304e469da06d5f15710fab5dd3ce013aa1b73"  # pylint: disable=line-too-long
 RHELAI_IMAGE = "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:b3dc9af0244aa6b84e6c3ef53e714a316daaefaae67e28de397cd71ee4b2ac7e"  # pylint: disable=line-too-long
 
 # SDG


### PR DESCRIPTION
Corrects changes from #199 

The `standalone.py` is a generated file from `standalone.tpl`. Manual edits to `standalone.tpl` are overwritten by `make standalone`. Please refrain from changing `standalone.py` file manually.