### PR TITLE
ci: fail if standalone.py changed and standalone.tpl did not

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Needed for HEAD to exists
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -45,3 +47,14 @@ jobs:
         run: |
           pipenv run make pipeline
           git diff --exit-code || (echo "Pipeline is not up-to-date. Please run 'make pipeline' and commit the changes." && exit 1)
+
+      - name: test if standalone.py was updated and not standalone.tpl (no components file(s) updated)
+        if: "!contains(github.event.pull_request.labels.*.name, 'ignore-standalone-change')"
+        run: |
+          files_changed=$(git diff --name-only HEAD^)
+          echo "Files changed: $files_changed"
+          if [[ $files_changed == *"standalone.py"* && $files_changed != *"standalone.tpl"* && $files_changed != *"components.py"* ]]; then
+            echo "standalone.py was updated but not standalone.tpl."
+            echo "Please update standalone.tpl and run 'make standalone'."
+            exit 1
+          fi


### PR DESCRIPTION
1d45668 ci: fail if standalone.py changed and standalone.tpl did not

commit 1d45668af0f8e79a5c5bb106286b3b31c067b521
Author: Sébastien Han <seb@redhat.com>
Date:   Fri Nov 22 10:03:33 2024 +0100

    ci: fail if standalone.py changed and standalone.tpl did not
    
    This commit adds to the pre-commit hook a check to verify that changes
    to standalone.py are accompanied by corresponding updates to
    standalone.tpl. The check will fail if standalone.py is updated without
    updating standalone.tpl ONLY if no components file(s) is/are updated.
    This ensures consistency between standalone.py and standalone.tpl, and
    prompts the user to run 'make standalone' if necessary. The check can be
    bypassed by adding the 'ignore-standalone-change' label to the pull
    request.
    
    Signed-off-by: Sébastien Han <seb@redhat.com>
