### PR TITLE
feat(cli): run pipeline from CLI directly

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,10 +6,10 @@
 #    final_eval_few_shots: int [Default: 5.0]
 #    final_eval_max_workers: str [Default: 'auto']
 #    final_eval_merge_system_user_message: bool [Default: False]
-#    k8s_storage_class_name: str [Default: 'nfs-csi']
+#    k8s_storage_class_name: str [Default: 'standard']
 #    mt_bench_max_workers: str [Default: 'auto']
 #    mt_bench_merge_system_user_message: bool [Default: False]
-#    sdg_base_model: str [Default: 's3://ilab-pipeline-b1d4c2b1-ab00-4e7f-b985-697bda3df385/instructlab-base-importer/648f36d0-e3f0-43b8-8adb-530576beb675/ilab-importer-op/model/granite-7b-starter']
+#    sdg_base_model: str [Default: 's3://<BUCKET>/<PATH_TO_MODEL>']
 #    sdg_max_batch_len: int [Default: 20000.0]
 #    sdg_pipeline: str [Default: 'simple']
 #    sdg_repo_branch: str
@@ -2042,7 +2042,7 @@ root:
         isOptional: true
         parameterType: BOOLEAN
       k8s_storage_class_name:
-        defaultValue: nfs-csi
+        defaultValue: standard
         description: A Kubernetes StorageClass name for persistent volumes. Selected
           StorageClass must support RWX PersistentVolumes.
         isOptional: true
@@ -2060,7 +2060,7 @@ root:
         isOptional: true
         parameterType: BOOLEAN
       sdg_base_model:
-        defaultValue: s3://ilab-pipeline-b1d4c2b1-ab00-4e7f-b985-697bda3df385/instructlab-base-importer/648f36d0-e3f0-43b8-8adb-530576beb675/ilab-importer-op/model/granite-7b-starter
+        defaultValue: s3://<BUCKET>/<PATH_TO_MODEL>
         description: SDG parameter. LLM model used to generate the synthetic dataset
         isOptional: true
         parameterType: STRING

--- a/utils/kfp_client.py
+++ b/utils/kfp_client.py
@@ -1,0 +1,56 @@
+# type: ignore
+import warnings
+
+from kfp import Client
+from kubernetes.client import CustomObjectsApi
+from kubernetes.client.configuration import Configuration
+from kubernetes.client.exceptions import ApiException
+from kubernetes.config import list_kube_config_contexts
+from kubernetes.config.config_exception import ConfigException
+from kubernetes.config.kube_config import load_kube_config
+
+
+def get_kfp_client():
+    config = Configuration()
+    try:
+        load_kube_config(client_configuration=config)
+        token = config.api_key["authorization"].split(" ")[-1]
+    except (KeyError, ConfigException) as e:
+        raise ApiException(
+            401, "Unauthorized, try running `oc login` command first"
+        ) from e
+    Configuration.set_default(config)
+
+    _, active_context = list_kube_config_contexts()
+    namespace = active_context["context"]["namespace"]
+
+    dspas = CustomObjectsApi().list_namespaced_custom_object(
+        "datasciencepipelinesapplications.opendatahub.io",
+        "v1alpha1",
+        namespace,
+        "datasciencepipelinesapplications",
+    )
+
+    try:
+        dspa = dspas["items"][0]
+    except IndexError as e:
+        raise ApiException(404, "DataSciencePipelines resource not found") from e
+
+    try:
+        if dspa["spec"]["dspVersion"] != "v2":
+            raise KeyError
+    except KeyError as e:
+        raise EnvironmentError(
+            "Installed version of Kubeflow Pipelines does not meet minimal version criteria. Use KFPv2 please."
+        ) from e
+
+    try:
+        host = dspa["status"]["components"]["apiServer"]["externalUrl"]
+    except KeyError as e:
+        raise ApiException(
+            409,
+            "DataSciencePipelines resource is not ready. Check for .status.components.apiServer",
+        ) from e
+
+    with warnings.catch_warnings(action="ignore"):
+        return Client(existing_token=token, host=host)


### PR DESCRIPTION
Follow up to: https://github.com/opendatahub-io/ilab-on-ocp/pull/202#issuecomment-2498046040

~@MichaelClifford, @Shreyanand  can you please help me understand the default values we set here and if **ALL** of them make sense in a generic environment. I've made a check-list in code via `FIXME:` comments. Be aware that the default values are not necessarily expected to work in the MOC cluster/`ilab` namespace context.~ (Removed from the PR, we can revisit this separatelly.)


This PR allows us to submit the pipeline run directly via CLI with no drag-and-drop-in-UI-slavery anymore...


All params are optional but allows you to control things:
```bash
$ python pipeline.py run --help
Usage: pipeline.py run [OPTIONS]

  Run the pipeline immediately against current kubernetes context (cluster and
  namespace).

  Command sets expected dev-cluster friendly default values when submitting.

Options:
  --mock [sdg|train|eval]  Mock part of the pipeline
  -e, --experiment TEXT    Set KFP experiment name.
  -r, --run TEXT           Set KFP run name.
  -p, --param TEXT         Override default parameters in KEY=VALUE format.
                           Default parameters are suitable for dev cluster -
                           the MOC cluster, `ilab` namespace.
  --help                   Show this message and exit.

```

Submitting a run then looks like this:

```bash
$ python pipeline.py run
Experiment details: https://ds-pipeline-dspa-ilab.apps.ocp-beta-test.nerc.mghpcc.org/#/experiments/details/f3fb689f-8f38-4822-9b6c-aa1c51d8d121
Run details: https://ds-pipeline-dspa-ilab.apps.ocp-beta-test.nerc.mghpcc.org/#/runs/details/2e5bb117-3a3d-44ed-bd11-49864f16df45
```