### PR TITLE
Add kfto sdk to the rhoai-ilab-image containerfile

### DIFF
--- a/rhoai-ilab-image/Containerfile
+++ b/rhoai-ilab-image/Containerfile
@@ -1,3 +1,4 @@
 FROM registry.redhat.io/rhelai1/instructlab-nvidia-rhel9:1.2
 
 RUN pip install kfp==2.9.0
+RUN pip install kubeflow-training


### PR DESCRIPTION
The PR adds `kubeflow-training` package to the Containerfile to test launching Pytorch jobs from the kfto training client SDK. 
