### PR TITLE
[phase-1] Download models from oci based registry

### DIFF
--- a/standalone/instructlab-rhoai.md
+++ b/standalone/instructlab-rhoai.md
@@ -43,9 +43,10 @@ Before running the training and evaluation steps we must complete the following:
   ```
 
 * Download ilab model repository in s3-data model direct
+
   ```
-  $ ilab model download --repository ibm-granite/granite-7b-base
-  $ cp -r <path-to-model-downloaded-dir>/ibm-granite/granite-7b-base/* s3-data/model
+  $ ilab model download --repository docker://registry.redhat.io/rhelai1/granite-7b-starter --release 1.2-1728663941
+  $ cp -r <path-to-model-downloaded-dir>/granite-7b-starter/* s3-data/model
   ```
 
 * Clone taxonomy repository (this could be any taxonomy repo and any branches in the given repo)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Update RHELAI docs to enable model downloading from OCI registries

### How to use it

To download ilab models from OCI registries following the following instructions
> [!NOTE]
> [skopeo](https://github.com/containers/skopeo/) must be installed and policy.json file present in `$HOME/.config/containers/policy.json` or `/etc/containers/policy.json`
> If you don't have skopeo policy, you can download default policy from [here](https://github.com/containers/skopeo/blob/main/default-policy.json)
  ```bash
  $ ilab model download --repository docker://registry.redhat.io/rhelai1/granite-7b-starter --release 1.2-1728663941
  $ cp -r <path-to-model-downloaded-dir>/granite-7b-starter/* s3-data/model
  ```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
