### PR TITLE
Revert "update RHELAI_IMAGE to 1.3"

### DIFF
--- a/importer-pipeline.yaml
+++ b/importer-pipeline.yaml
@@ -32,7 +32,7 @@ deploymentSpec:
         env:
         - name: REGISTRY_AUTH_FILE
           value: /mnt/containers/.dockerconfigjson
-        image: quay.io/redhat-et/ilab:1.3
+        image: quay.io/redhat-et/ilab:1.2
 pipelineInfo:
   description: Helper pipeline to the InstructLab pipeline which allows users to seed/import
     a new base model

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -645,7 +645,7 @@ deploymentSpec:
           \                max_seq_len=train_args.max_seq_len,\n                chat_tmpl_path=train_args.chat_tmpl_path,\n\
           \            )\n        )\n\n    data_processing(train_args=skill_training_args)\n\
           \    data_processing(train_args=knowledge_training_args)\n\n"
-        image: quay.io/redhat-et/ilab:1.3
+        image: quay.io/redhat-et/ilab:1.2
     exec-deletepvc:
       container:
         image: argostub/deletepvc
@@ -1376,7 +1376,7 @@ deploymentSpec:
           value: /tmp
         - name: HF_HOME
           value: /tmp
-        image: quay.io/redhat-et/ilab:1.3
+        image: quay.io/redhat-et/ilab:1.2
         resources:
           accelerator:
             count: '1'
@@ -1512,7 +1512,7 @@ deploymentSpec:
           value: /tmp
         - name: HF_HOME
           value: /tmp
-        image: quay.io/redhat-et/ilab:1.3
+        image: quay.io/redhat-et/ilab:1.2
         resources:
           accelerator:
             count: '1'
@@ -1569,7 +1569,7 @@ deploymentSpec:
           value: /tmp
         - name: HF_HOME
           value: /tmp
-        image: quay.io/redhat-et/ilab:1.3
+        image: quay.io/redhat-et/ilab:1.2
     exec-sdg-to-artifact-op:
       container:
         args:

--- a/utils/consts.py
+++ b/utils/consts.py
@@ -1,4 +1,4 @@
 PYTHON_IMAGE = "quay.io/modh/odh-generic-data-science-notebook:v3-2024b-20241111"
 TOOLBOX_IMAGE = "registry.access.redhat.com/ubi9/toolbox"
 OC_IMAGE = "registry.redhat.io/openshift4/ose-cli"
-RHELAI_IMAGE = "quay.io/redhat-et/ilab:1.3"
+RHELAI_IMAGE = "quay.io/redhat-et/ilab:1.2"


### PR DESCRIPTION
Reverts opendatahub-io/ilab-on-ocp#222 Reverts opendatahub-io/ilab-on-ocp#225 as simply switching out the RHEL AI images will break the current pipeline. Going to make these change in a larger PR along with fixes needed for RHEL AI 1.3 