### PR TITLE
set caching to False for output_mt_bench_task

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -411,6 +411,8 @@ def ilab_pipeline_wrapper(mock: List[Literal[MOCKED_STAGES]]):
             pvc_path="/output/mt_bench_data.json",
         )
         output_mt_bench_task.after(run_mt_bench_task)
+        output_mt_bench_task.set_caching_options(False)
+
         mount_pvc(
             task=output_mt_bench_task,
             pvc_name=output_pvc_task.output,

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1845,8 +1845,7 @@ root:
         taskInfo:
           name: pvc-to-model-op
       pvc-to-mt-bench-op:
-        cachingOptions:
-          enableCache: true
+        cachingOptions: {}
         componentRef:
           name: comp-pvc-to-mt-bench-op
         dependentTasks:


### PR DESCRIPTION
This PR sets `outpiut_mt_bench_task` caching option to `False`. Otherwise, this can lead to instances where the MT-bench data changes, but the MT-bench data artifacts do not get updated, causing a mismatch between the evaluation run and the evaluation values reported.  
