### PR TITLE
set agentic as default

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -76,7 +76,7 @@ def ilab_pipeline(
     ] = None,  # FIXME: https://issues.redhat.com/browse/RHOAIRFE-467
     sdg_base_model: str = "s3://<BUCKET>/<PATH_TO_MODEL>",
     sdg_scale_factor: int = 30,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L125
-    sdg_pipeline: str = "full",  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L122
+    sdg_pipeline: str = "/usr/share/instructlab/sdg/pipelines/agentic",  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L122
     sdg_max_batch_len: int = 5000,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L334
     sdg_sample_size: float = 1.0,  # FIXME: Not present in default config. Not configurable upstream at this point, capability added via https://github.com/instructlab/sdg/pull/432
     # Training phase

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -11,7 +11,7 @@
 #    mt_bench_merge_system_user_message: bool [Default: False]
 #    sdg_base_model: str [Default: 's3://<BUCKET>/<PATH_TO_MODEL>']
 #    sdg_max_batch_len: int [Default: 5000.0]
-#    sdg_pipeline: str [Default: 'full']
+#    sdg_pipeline: str [Default: '/usr/share/instructlab/sdg/pipelines/agentic']
 #    sdg_repo_branch: str
 #    sdg_repo_pr: int
 #    sdg_repo_url: str [Default: 'https://github.com/instructlab/taxonomy.git']
@@ -2019,7 +2019,7 @@ root:
         isOptional: true
         parameterType: NUMBER_INTEGER
       sdg_pipeline:
-        defaultValue: full
+        defaultValue: /usr/share/instructlab/sdg/pipelines/agentic
         description: 'SDG parameter. Data generation pipeline to use. Available: ''simple'',
           ''full'', or a valid path to a directory of pipeline workflow YAML files.
           Note that ''full'' requires a larger teacher model, Mixtral-8x7b.'


### PR DESCRIPTION
Possibly controversial, this one is to make the rhoai ilab tuning experience a bit more seamless, as it's a bit awkward to have to have the user provide this. 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
