### PR TITLE
Make sdg_op dependent on prerequisites step to run

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -198,6 +198,7 @@ def ilab_pipeline(
         size=k8s_storage_size,
         storage_class_name=k8s_storage_class_name,
     )
+    sdg_input_pvc_task.after(prerequisites_check_task)
 
     model_tokenizer_source_task = dsl.importer(
         artifact_uri=f"oci://{RUNTIME_GENERIC_IMAGE}", artifact_class=dsl.Model
@@ -228,6 +229,7 @@ def ilab_pipeline(
         mount_path="/data",
     )
     sdg_task.set_caching_options(False)
+    sdg_task.after(prerequisites_check_task)
 
     # Upload "sdg" and "taxonomy" artifacts to S3 without blocking the rest of the workflow
     taxonomy_to_artifact_task = taxonomy_to_artifact_op()

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2089,7 +2089,7 @@ deploymentSpec:
           \n    with client.ApiClient() as api_client:\n        core_api = client.CoreV1Api(api_client)\n\
           \n        try:\n            secret = core_api.read_namespaced_secret(secret_name,\
           \ namespace)\n            print(f\"Reading secret {secret_name} data...\"\
-          )\n            model_api_key = base64.b64decode(secret.data[\"api_key\"\
+          )\n            model_api_key = base64.b64decode(secret.data[\"api_token\"\
           ]).decode(\"utf-8\")\n            model_name = base64.b64decode(secret.data[\"\
           model_name\"]).decode(\"utf-8\")\n            model_endpoint = base64.b64decode(secret.data[\"\
           endpoint\"]).decode(\"utf-8\")\n        except (ApiException, KeyError)\
@@ -2157,7 +2157,7 @@ deploymentSpec:
           \n    with client.ApiClient() as api_client:\n        core_api = client.CoreV1Api(api_client)\n\
           \n        try:\n            secret = core_api.read_namespaced_secret(secret_name,\
           \ namespace)\n            print(f\"Reading secret {secret_name} data...\"\
-          )\n            model_api_key = base64.b64decode(secret.data[\"api_key\"\
+          )\n            model_api_key = base64.b64decode(secret.data[\"api_token\"\
           ]).decode(\"utf-8\")\n            model_name = base64.b64decode(secret.data[\"\
           model_name\"]).decode(\"utf-8\")\n            model_endpoint = base64.b64decode(secret.data[\"\
           endpoint\"]).decode(\"utf-8\")\n        except (ApiException, KeyError)\
@@ -2222,9 +2222,9 @@ deploymentSpec:
           \        print(f\"\"\"\n        ########################### INFO ##############################\n\
           \        # Model Registry endpoint is not provided. Skipping this step #\n\
           \        ###############################################################\n\
-          \        \"\"\")\n\n    try:\n        # Extract the port out of the URL\
-          \ because the ModelRegistry client expects those as separate arguments.\n\
-          \        model_registry_api_url_parsed = urllib.parse.urlparse(model_registry_endpoint)\n\
+          \        \"\"\")\n        return\n\n    try:\n        # Extract the port\
+          \ out of the URL because the ModelRegistry client expects those as separate\
+          \ arguments.\n        model_registry_api_url_parsed = urllib.parse.urlparse(model_registry_endpoint)\n\
           \        model_registry_api_url_port = model_registry_api_url_parsed.port\n\
           \n        if model_registry_api_url_port:\n            model_registry_api_server_address\
           \ = model_registry_endpoint.replace(\n                model_registry_api_url_parsed.netloc,\n\
@@ -2530,6 +2530,8 @@ root:
           enableCache: true
         componentRef:
           name: comp-createpvc
+        dependentTasks:
+        - prerequisites-check-op
         inputs:
           parameters:
             access_modes:
@@ -2980,6 +2982,7 @@ root:
         dependentTasks:
         - createpvc
         - importer
+        - prerequisites-check-op
         inputs:
           artifacts:
             tokenizer_model:

--- a/utils/components.py
+++ b/utils/components.py
@@ -337,7 +337,7 @@ def test_model_connection(secret_name: str):
         try:
             secret = core_api.read_namespaced_secret(secret_name, namespace)
             print(f"Reading secret {secret_name} data...")
-            model_api_key = base64.b64decode(secret.data["api_key"]).decode("utf-8")
+            model_api_key = base64.b64decode(secret.data["api_token"]).decode("utf-8")
             model_name = base64.b64decode(secret.data["model_name"]).decode("utf-8")
             model_endpoint = base64.b64decode(secret.data["endpoint"]).decode("utf-8")
         except (ApiException, KeyError) as e:
@@ -398,6 +398,7 @@ def test_model_registry(
         # Model Registry endpoint is not provided. Skipping this step #
         ###############################################################
         """)
+        return
 
     try:
         # Extract the port out of the URL because the ModelRegistry client expects those as separate arguments.


### PR DESCRIPTION
## Description
sdg_op task was still running even when prerequisites_op failed. Added a dependency in the task, as well as the create-pvc task used by sdg_op.

In addition to that, fixed a return conditional in model registry check to skip the step if model registry url is not provided, and the secret key to retrieve the model API token.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Import the pipeline yaml in this PR
* Create a run with a missing Model Registry URL and provide wrong secret for the models. This is important to make one of the prerequisites checks to fail
* After any of the prerequisites sub DAG fails, Dashboard should return a Failed status for the pipeline run

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
