### PR TITLE
Fix the Modelcar path for latest ODH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON_IMAGE          ?= "quay.io/modh/odh-generic-data-science-notebook@sha256:
 TOOLBOX_IMAGE         ?= "registry.redhat.io/ubi9/toolbox@sha256:da31dee8904a535d12689346e65e5b00d11a6179abf1fa69b548dbd755fa2770"                     # v9.5
 OC_IMAGE              ?= "registry.redhat.io/openshift4/ose-cli@sha256:08bdbfae224dd39c81689ee73c183619d6b41eba7ac04f0dce7ee79f50531d0b"               # v4.15.0
 RHELAI_IMAGE          ?= "registry.redhat.io/rhelai1/instructlab-nvidia-rhel9@sha256:c656c74338e3d59bf265e4b2fa9c01a69c8212992fa6d4511aef52a441506e68" # 1.4.1-1739870750
-RUNTIME_GENERIC_IMAGE ?= "quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a"    # main-081db08
+RUNTIME_GENERIC_IMAGE ?= "quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d"    # main-abe4fd9
 
 pipeline:
 	PYTHON_IMAGE=$(PYTHON_IMAGE) \

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -994,7 +994,7 @@ deploymentSpec:
     exec-importer:
       importer:
         artifactUri:
-          constant: oci://quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+          constant: oci://quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
         typeSchema:
           schemaTitle: system.Model
           schemaVersion: 0.0.1
@@ -1040,7 +1040,7 @@ deploymentSpec:
           \ f)\n        print(f\"Copying {src} to {dest}\")\n        if os.path.isdir(src):\n\
           \            shutil.copytree(src, dest)\n        else:\n            shutil.copy(src,\
           \ dest)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-pvc-to-mmlu-branch-op:
       container:
         args:
@@ -1854,9 +1854,9 @@ deploymentSpec:
           \      return match.group(1)  # Extracted host\n        raise ValueError(f\"\
           Invalid SSH repository URL: {repo_url}\")\n\n    tokenizer_model_path =\
           \ tokenizer_model.path\n    if tokenizer_model_path.startswith(\"oci://\"\
-          ):\n        # Handle where the KFP SDK is <2.12.0.\n        escaped_uri\
-          \ = tokenizer_model_path[len(\"oci://\") :].replace(\"/\", \"\\\\/\")\n\
-          \        tokenizer_model_path = os.path.join(\"/oci\", escaped_uri, \"models\"\
+          ):\n        # Handle where the KFP SDK is <2.12.2.\n        escaped_uri\
+          \ = tokenizer_model_path[len(\"oci://\") :].replace(\"/\", \"_\")\n    \
+          \    tokenizer_model_path = os.path.join(\"/oci\", escaped_uri, \"models\"\
           )\n\n    # A hack because InstructLab assumes the value for model_name is\
           \ a valid path and the name of the model.\n    os.symlink(tokenizer_model_path,\
           \ os.path.join(tempfile.gettempdir(), \"mixtral\"))\n    os.chdir(tempfile.gettempdir())\n\
@@ -2115,7 +2115,7 @@ deploymentSpec:
           \ Server {model_name} is unavailable. Ensure the model is up and it is ready\
           \ to serve requests. #\n    #######################################################################################################\\\
           \n    \"\"\")\n    )\n    sys.exit(1)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-model-connection-2:
       container:
         args:
@@ -2175,7 +2175,7 @@ deploymentSpec:
           \ Server {model_name} is unavailable. Ensure the model is up and it is ready\
           \ to serve requests. #\n    #######################################################################################################\\\
           \n    \"\"\")\n    )\n    sys.exit(1)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-model-registry:
       container:
         args:
@@ -2235,7 +2235,7 @@ deploymentSpec:
           \ ############# ERROR ###############\n        # Model Registry is not available\
           \ #\n        ###################################\\\n        \"\"\")\n  \
           \      )\n        raise\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-oci-model:
       container:
         args:
@@ -2296,7 +2296,7 @@ deploymentSpec:
           \"\"\\\n            ################## ERROR ##################\n      \
           \      # Failed to check oci model and/or secret #\n            ###########################################\\\
           \n            \"\"\")\n            )\n            raise\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-sdg-params:
       container:
         args:
@@ -2329,7 +2329,7 @@ deploymentSpec:
           \    ############# INFO #############\n            # The SDG parameters\
           \ seem okay #\n            ################################\\\n        \
           \    \"\"\"\n        )\n    )\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-taxonomy-repo:
       container:
         args:
@@ -2346,7 +2346,7 @@ deploymentSpec:
         command:
         - /bin/sh
         - -c
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-test-training-operator:
       container:
         args:
@@ -2385,7 +2385,7 @@ deploymentSpec:
           \ Ensure your OpenShift AI installation has Training Operator enabled #\n\
           \            #################################################################################################################################\\\
           \n            \"\"\")\n            )\n            sys.exit(1)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
     exec-upload-model-op:
       container:
         args:
@@ -2518,7 +2518,7 @@ deploymentSpec:
           modelVersionName\"] = output_model_version\n    model.metadata[\"modelVersionId\"\
           ] = model_version_id\n    model.metadata[\"registeredModelId\"] = registered_model.id\n\
           \n"
-        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+        image: quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
 pipelineInfo:
   description: InstructLab pipeline
   displayName: InstructLab
@@ -2679,7 +2679,7 @@ root:
           parameters:
             uri:
               runtimeValue:
-                constant: oci://quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:b53a607cd4efa86a594da68586613e916ed4b7c626e8a7e793d75e0bd15e815a
+                constant: oci://quay.io/opendatahub/ds-pipelines-runtime-generic@sha256:f53e53a39b1a88c3a530e87ded473ba2648b8d8586ec9e31a4484e9bafb3059d
         taskInfo:
           name: importer
       importer-2:

--- a/sdg/components.py
+++ b/sdg/components.py
@@ -159,8 +159,8 @@ def sdg_op(
 
     tokenizer_model_path = tokenizer_model.path
     if tokenizer_model_path.startswith("oci://"):
-        # Handle where the KFP SDK is <2.12.0.
-        escaped_uri = tokenizer_model_path[len("oci://") :].replace("/", "\\/")
+        # Handle where the KFP SDK is <2.12.2.
+        escaped_uri = tokenizer_model_path[len("oci://") :].replace("/", "_")
         tokenizer_model_path = os.path.join("/oci", escaped_uri, "models")
 
     # A hack because InstructLab assumes the value for model_name is a valid path and the name of the model.


### PR DESCRIPTION
## Description

This accounts for bug fix in:
https://github.com/opendatahub-io/data-science-pipelines/commit/5dc04019cd3564690b78ad77c1ebd11a1473a0e0

## How Has This Been Tested?

I tested an InstructLab pipeline and saw that the starter Granite model was properly copied to the PVC and the SDG step correctly saw the Mixtral tokenizer.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
