### PR TITLE
Fix test model registry task & other enhancements

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -79,7 +79,7 @@ def ilab_pipeline(
     train_gpu_identifier: str = "nvidia.com/gpu",
     train_gpu_per_worker: int = 2,  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
     train_cpu_per_worker: str = "2",  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
-    train_memory_per_worker: str = "2Gi",  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
+    train_memory_per_worker: str = "56Gi",  # Default value set after observing the memory requirements when running the pipeline
     train_num_workers: int = 2,  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
     train_num_epochs_phase_1: int = 7,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L364
     train_num_epochs_phase_2: int = 10,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L377
@@ -136,7 +136,7 @@ def ilab_pipeline(
         train_gpu_identifier: Training parameter. The GPU type used for training pods, e.g. nvidia.com/gpu
         train_gpu_per_worker: Training parameter. Number of GPUs per each node/worker to use for training.
         train_cpu_per_worker: Training parameter. Number of CPUs per each node/worker to use for training.
-        train_memory_per_worker: Training parameter. Memory per GPU per each node/worker to use for training.
+        train_memory_per_worker: Training parameter. Memory per GPU per each node/worker to use for training. 56Gi or more is recommended
         train_num_workers: Training parameter. Number of nodes/workers to train on.
         train_num_epochs_phase_1: Training parameter for in Phase 1. Number of epochs to run training.
         train_num_epochs_phase_2: Training parameter for in Phase 2. Number of epochs to run training.
@@ -161,7 +161,7 @@ def ilab_pipeline(
         eval_gpu_identifier: General evaluation parameter. The GPU type used for training pods, e.g. nvidia.com/gpu
         eval_judge_secret: General evaluation parameter: The name of the k8s secret key holding access credentials to the judge server.
 
-        k8s_storage_class_name: A Kubernetes StorageClass name for persistent volumes. Selected StorageClass must support RWX PersistentVolumes.
+        k8s_storage_class_name: A Kubernetes StorageClass name for persistent volumes. Selected StorageClass must support ReadWriteMany(RWX) PersistentVolume access mode.
         k8s_storage_size: The storage size of the persistent volume used for data passing within the pipeline.
     """
     # Pre-requisites check stage

--- a/pipeline.py
+++ b/pipeline.py
@@ -128,8 +128,8 @@ def ilab_pipeline(
         sdg_pipeline: SDG parameter. Data generation pipeline to use. Available: 'simple', 'full', or a valid path to a directory of pipeline workflow YAML files. Note that 'full' requires a larger teacher model, Mixtral-8x7b.
         sdg_max_batch_len: SDG parameter. Maximum tokens per gpu for each batch that will be handled in a single step.
         sdg_sample_size: SDG parameter. Represents the sdg skills recipe sampling size as percentage in decimal form.
-        sdg_batch_size: SDG parameter. The number of completions to per request to the teacher model. This can be increased to improve SDG performance based on the hardware of the teacher model.
-        sdg_num_workers: SDG parameter. The number of concurrent workers sending completion requests. This can be increased to improve SDG performance based on the hardware of the teacher model.
+        sdg_batch_size: SDG parameter. The number of completions per request to the teacher model. This can be increased to improve SDG performance based on the hardware of the teacher model or reduced if SDG fails due to connection errors with the teacher model.
+        sdg_num_workers: SDG parameter. The number of concurrent workers sending completion requests to the teacher model. This can be increased to improve SDG performance based on the hardware of the teacher model or reduced if SDG fails due to connection errors with the teacher model. Batching is disabled when sdg_num_workers=1.
 
         train_tolerations: Training parameter. List of tolerations applied to training pods.
         train_node_selectors: Training parameter. A JSON containing node selectors applied to training pods.

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -39,7 +39,7 @@
 #    train_learning_rate_phase_1: float [Default: 2e-05]
 #    train_learning_rate_phase_2: float [Default: 6e-06]
 #    train_max_batch_len: int [Default: 5000.0]
-#    train_memory_per_worker: str [Default: '2Gi']
+#    train_memory_per_worker: str [Default: '56Gi']
 #    train_node_selectors: dict
 #    train_num_epochs_phase_1: int [Default: 7.0]
 #    train_num_epochs_phase_2: int [Default: 10.0]
@@ -3135,7 +3135,7 @@ root:
       k8s_storage_class_name:
         defaultValue: standard
         description: A Kubernetes StorageClass name for persistent volumes. Selected
-          StorageClass must support RWX PersistentVolumes.
+          StorageClass must support ReadWriteMany(RWX) PersistentVolume access mode.
         isOptional: true
         parameterType: STRING
       k8s_storage_size:
@@ -3316,9 +3316,9 @@ root:
         isOptional: true
         parameterType: NUMBER_INTEGER
       train_memory_per_worker:
-        defaultValue: 2Gi
+        defaultValue: 56Gi
         description: Training parameter. Memory per GPU per each node/worker to use
-          for training.
+          for training. 56Gi or more is recommended
         isOptional: true
         parameterType: STRING
       train_node_selectors:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -2212,7 +2212,8 @@ deploymentSpec:
           \        ###############################################################\\\
           \n        \"\"\")\n        )\n        return\n\n    try:\n        # Extract\
           \ the port out of the URL because the ModelRegistry client expects those\
-          \ as separate arguments.\n        model_registry_api_url_parsed = urllib.parse.urlparse(model_registry_endpoint)\n\
+          \ as separate arguments.\n        model_registry_endpoint = model_registry_endpoint.rstrip(\"\
+          /\")\n        model_registry_api_url_parsed = urllib.parse.urlparse(model_registry_endpoint)\n\
           \        model_registry_api_url_port = model_registry_api_url_parsed.port\n\
           \n        if model_registry_api_url_port:\n            model_registry_api_server_address\
           \ = model_registry_endpoint.replace(\n                model_registry_api_url_parsed.netloc,\n\
@@ -2325,7 +2326,7 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef test_sdg_params(sdg_batch_size: int, sdg_num_workers: int):\n\
           \    import sys\n    import textwrap\n\n    if (\n        sdg_batch_size\
-          \ < 1\n        or sdg_batch_size > 4096\n        or sdg_num_workers < 2\n\
+          \ < 1\n        or sdg_batch_size > 4096\n        or sdg_num_workers < 1\n\
           \        or sdg_num_workers > 10\n    ):\n        print(\n            textwrap.dedent(\n\
           \                f\"\"\"\\\n                ##############################################\
           \ ERROR ##############################################\n               \
@@ -3198,9 +3199,10 @@ root:
         parameterType: STRING
       sdg_batch_size:
         defaultValue: 128.0
-        description: SDG parameter. The number of completions to per request to the
-          teacher model. This can be increased to improve SDG performance based on
-          the hardware of the teacher model.
+        description: SDG parameter. The number of completions per request to the teacher
+          model. This can be increased to improve SDG performance based on the hardware
+          of the teacher model or reduced if SDG fails due to connection errors with
+          the teacher model.
         isOptional: true
         parameterType: NUMBER_INTEGER
       sdg_max_batch_len:
@@ -3212,8 +3214,9 @@ root:
       sdg_num_workers:
         defaultValue: 2.0
         description: SDG parameter. The number of concurrent workers sending completion
-          requests. This can be increased to improve SDG performance based on the
-          hardware of the teacher model.
+          requests to the teacher model. This can be increased to improve SDG performance
+          based on the hardware of the teacher model or reduced if SDG fails due to
+          connection errors with the teacher model. Batching is disabled when sdg_num_workers=1.
         isOptional: true
         parameterType: NUMBER_INTEGER
       sdg_pipeline:

--- a/utils/components.py
+++ b/utils/components.py
@@ -394,7 +394,7 @@ def test_sdg_params(sdg_batch_size: int, sdg_num_workers: int):
     if (
         sdg_batch_size < 1
         or sdg_batch_size > 4096
-        or sdg_num_workers < 2
+        or sdg_num_workers < 1
         or sdg_num_workers > 10
     ):
         print(

--- a/utils/components.py
+++ b/utils/components.py
@@ -444,6 +444,7 @@ def test_model_registry(
 
     try:
         # Extract the port out of the URL because the ModelRegistry client expects those as separate arguments.
+        model_registry_endpoint = model_registry_endpoint.rstrip("/")
         model_registry_api_url_parsed = urllib.parse.urlparse(model_registry_endpoint)
         model_registry_api_url_port = model_registry_api_url_parsed.port
 


### PR DESCRIPTION

- Delete last / of model_registry_endpoint to fix connection errors
- Allow sdg_num_workers = 1
- Set default train_memory_per_worker to 56Gi

Tested successfully in a pipeline run (more details in this [slack thread](https://redhat-internal.slack.com/archives/C062MMU059S/p1743172827907329?thread_ts=1743170418.713919&cid=C062MMU059S))