### PR TITLE
update to use k8s auth/ssh secret types for sdg repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ oc -n <data-science-project-name/namespace> oc apply -f oci_output_push_secret.y
 
 Note the `metadata.name` of this secret, you will need this when filling out the InstructLab pipeline parameters.
 
+## Taxonomy Repo
+
+As per the [SDG taxonomy tree] documentation, you should have a taxonomy git repo ready. When running the pipeline in the following step, you will be prompted for an optional `sdg_repo_secret` parameter.
+
+This is useful if your taxonomy repo is private. In such a case you can provide a kubernetes `Secret` of type either [basic-auth] or [ssh-auth]. Follow these instructions to create your secret.
+If using `basic-auth`, provide your Git access token as the `password`. It is required that these credentials are applicable to not only the parent taxonomy repo, but also any nested repo provided within
+each individual qna file.
+
+By default the secret name `taxonomy-repo-secret` is used, or you can opt to provide another secret under the `sdg_repo_secret` field.
+
+
 ## Run the Pipeline
 
 Now that all the cluster requirements have been set up, we are ready to upload and run our InstructLab pipeline!
@@ -115,3 +126,5 @@ For a troubleshooting guide see [here][troubleshooting].
 [nfs storage]: ./manifests/nfs_storage/nfs_storage.md
 [troubleshooting]: ./docs/troubleshooting.md
 [bug]: https://issues.redhat.com/browse/RHOAIENG-22522
+[basic-auth] : https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret
+[ssh-auth]: https://kubernetes.io/docs/concepts/configuration/secret/#ssh-authentication-secrets

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -1796,7 +1796,7 @@ deploymentSpec:
           \ subprocess\n    import sys\n    import tempfile\n    import urllib.parse\n\
           \n    import httpx\n    import instructlab.sdg\n    import openai\n    import\
           \ requests\n    import xdg_base_dirs\n    import yaml\n\n    REQUEST_TIMEOUT\
-          \ = 30  # seconds\n\n    def fetch_secret(secret_name, keys, optional=False):\n\
+          \ = 30  # seconds\n\n    def fetch_secret(secret_name, optional=False):\n\
           \        # Kubernetes API server inside the cluster\n        K8S_API_SERVER\
           \ = \"https://kubernetes.default.svc\"\n        NAMESPACE_PATH = \"/var/run/secrets/kubernetes.io/serviceaccount/namespace\"\
           \n        TOKEN_PATH = \"/var/run/secrets/kubernetes.io/serviceaccount/token\"\
@@ -1813,68 +1813,88 @@ deploymentSpec:
           \n        response = requests.get(\n            url, headers=headers, verify=verify_tls,\
           \ timeout=REQUEST_TIMEOUT\n        )\n\n        if response.status_code\
           \ == 200:\n            print(f\"Successfully fetched secret {secret_name}\"\
-          )\n            secret_data = response.json().get(\"data\", {})\n       \
-          \     values = []\n            for key in keys:\n                if key\
-          \ in secret_data:\n                    values.append(base64.b64decode(secret_data[key]).decode())\n\
-          \                else:\n                    values.append(None)\n      \
-          \      return values\n        elif optional and response.status_code ==\
-          \ 404:\n            return [None for _ in keys]\n        else:\n       \
-          \     raise RuntimeError(\n                f\"Error fetching secret: {response.status_code}\
-          \ {response.text}\"\n            )\n\n    # Configure Git Credentials (if\
-          \ provided) and environment\n\n    def exec_cmd(cmd, **kwarg):\n       \
-          \ if \"stdout\" in kwarg or \"stderr\" in kwarg:\n            # If stdout\
-          \ or stderr is explicitly set, remove capture_output to avoid conflicts\n\
-          \            res = subprocess.run(cmd, text=True, **kwarg)\n        else:\n\
-          \            # Default behavior (captures output)\n            res = subprocess.run(cmd,\
-          \ text=True, capture_output=True, **kwarg)\n        if res.stdout:\n   \
-          \         print(\"STDOUT:\", res.stdout)\n        if res.stderr:\n     \
-          \       print(\"STDERR:\", res.stderr)\n        if res.returncode != 0:\n\
-          \            raise RuntimeError(f\"CMD {cmd} failed with error code: {res.returncode}\"\
-          )\n        print(f\"Command {cmd} succeeded.\")\n\n    def is_ssh(uri: str)\
-          \ -> bool:\n        \"\"\"Checks if a given Git URI is an SSH-based URL.\"\
-          \"\"\n        ssh_patterns = [\n            r\"^git@[\\w.-]+:.+\",\n   \
-          \         r\"^ssh://.+\",\n        ]\n        return any(re.match(pattern,\
-          \ uri) for pattern in ssh_patterns)\n\n    def get_git_host(repo_url):\n\
-          \        \"\"\"Extracts the Git host (e.g., github.com, gitlab.com) from\
-          \ an SSH repository URL.\"\"\"\n        match = re.match(r\"git@([\\w.-]+):\"\
-          , repo_url)\n        if match:\n            return match.group(1)  # Extracted\
-          \ host\n        raise ValueError(f\"Invalid SSH repository URL: {repo_url}\"\
-          )\n\n    tokenizer_model_path = tokenizer_model.path\n    if tokenizer_model_path.startswith(\"\
-          oci://\"):\n        # Handle where the KFP SDK is <2.12.2.\n        escaped_uri\
+          )\n            return response.json()\n        elif optional and response.status_code\
+          \ == 404:\n            return None\n        else:\n            raise RuntimeError(\n\
+          \                f\"Error fetching secret: {response.status_code} {response.text}\"\
+          \n            )\n\n    # Configure Git Credentials (if provided) and environment\n\
+          \n    def exec_cmd(cmd, **kwarg):\n        if \"stdout\" in kwarg or \"\
+          stderr\" in kwarg:\n            # If stdout or stderr is explicitly set,\
+          \ remove capture_output to avoid conflicts\n            res = subprocess.run(cmd,\
+          \ text=True, **kwarg)\n        else:\n            # Default behavior (captures\
+          \ output)\n            res = subprocess.run(cmd, text=True, capture_output=True,\
+          \ **kwarg)\n        if res.stdout:\n            print(\"STDOUT:\", res.stdout)\n\
+          \        if res.stderr:\n            print(\"STDERR:\", res.stderr)\n  \
+          \      if res.returncode != 0:\n            raise RuntimeError(f\"CMD {cmd}\
+          \ failed with error code: {res.returncode}\")\n        print(f\"Command\
+          \ {cmd} succeeded.\")\n\n    def is_ssh(uri: str) -> bool:\n        \"\"\
+          \"Checks if a given Git URI is an SSH-based URL.\"\"\"\n        ssh_patterns\
+          \ = [\n            r\"^git@[\\w.-]+:.+\",\n            r\"^ssh://.+\",\n\
+          \        ]\n        return any(re.match(pattern, uri) for pattern in ssh_patterns)\n\
+          \n    def get_git_host(repo_url):\n        \"\"\"Extracts the Git host (e.g.,\
+          \ github.com, gitlab.com) from an SSH repository URL.\"\"\"\n        match\
+          \ = re.match(r\"git@([\\w.-]+):\", repo_url)\n        if match:\n      \
+          \      return match.group(1)  # Extracted host\n        raise ValueError(f\"\
+          Invalid SSH repository URL: {repo_url}\")\n\n    tokenizer_model_path =\
+          \ tokenizer_model.path\n    if tokenizer_model_path.startswith(\"oci://\"\
+          ):\n        # Handle where the KFP SDK is <2.12.2.\n        escaped_uri\
           \ = tokenizer_model_path[len(\"oci://\") :].replace(\"/\", \"_\")\n    \
           \    tokenizer_model_path = os.path.join(\"/oci\", escaped_uri, \"models\"\
           )\n\n    if not taxonomy_repo_secret:\n        username = os.getenv(\"GIT_USERNAME\"\
           )\n        token = os.getenv(\"GIT_TOKEN\")\n        ssh_key = os.getenv(\"\
           GIT_SSH_KEY\")\n    else:\n        print(\"SDG repo secret specified, fetching...\"\
-          )\n        username, token, ssh_key = fetch_secret(\n            taxonomy_repo_secret,\n\
-          \            [\"GIT_USERNAME\", \"GIT_TOKEN\", \"GIT_SSH_KEY\"],\n     \
-          \       optional=taxonomy_repo_secret == \"taxonomy-repo-secret\",\n   \
-          \     )\n        if username or ssh_key:\n            print(\"SDG repo secret\
-          \ data retrieved.\")\n        else:\n            print(\n              \
-          \  \"SDG repo secret content not available. Assuming the default pipeline\
-          \ parameter is unused.\"\n            )\n\n    # Whether not provided via\
-          \ env or secret\n    # Assume the repo is public\n    if not username or\
-          \ ssh_key:\n        print(\"No credentials provided for taxonomy repo, assuming\
-          \ public repo...\")\n\n    ssl_cert_dir = os.getenv(\"SSL_CERT_DIR\")\n\
-          \    ssl_cert_file = os.getenv(\"SSL_CERT_FILE\")\n    env = os.environ.copy()\n\
-          \n    # Set custom CA certificate if provided\n    # Consume this in the\
-          \ process execution environment\n    # This is required for read_taxonomy\
-          \ calls which\n    # Perform nested calls to git clones.\n    if ssl_cert_dir\
-          \ and os.path.exists(ssl_cert_dir):\n        print(f\"CA detected at {ssl_cert_dir}\"\
-          )\n        env[\"GIT_SSL_CAPATH\"] = ssl_cert_dir\n        os.environ[\"\
-          GIT_SSL_CAPATH\"] = ssl_cert_dir\n    elif ssl_cert_file and os.path.exists(ssl_cert_file):\n\
-          \        print(f\"CA detected at {ssl_cert_file}\")\n        env[\"GIT_SSL_CAINFO\"\
-          ] = ssl_cert_file\n        os.environ[\"GIT_SSL_CAINFO\"] = ssl_cert_file\n\
-          \    else:\n        print(\"No CA detected. Using the CA bundle in the container\
-          \ image.\")\n\n    git_credentials_path = \"\"\n    ssh_key_path = \"\"\n\
-          \    # Username/PAT takes precedence over ssh\n    if username and token:\n\
-          \        print(\"Configuring Git Credentials...\")\n        # Parse the\
-          \ domain from the repository URL\n        parsed_url = urllib.parse.urlparse(repo_url)\n\
-          \        git_server = parsed_url.netloc\n\n        # Set up Git credential\
-          \ helper\n        exec_cmd([\"git\", \"config\", \"--global\", \"credential.helper\"\
-          , \"store\"], env=env)\n\n        # Save credentials dynamically for any\
-          \ Git server\n        git_credentials_directory = os.path.expanduser(\"\
-          ~/.git\")\n        # Ensure the ~/.git directory exists\n        os.makedirs(git_credentials_directory,\
+          )\n        # When the user opts not provide a taxonomy repo secret\n   \
+          \     # to the pipeline, we use the default secret name below\n        is_optional\
+          \ = taxonomy_repo_secret == \"taxonomy-repo-secret\"\n        secret = fetch_secret(taxonomy_repo_secret,\
+          \ optional=is_optional)\n        username, token, ssh_key = \"\", \"\",\
+          \ \"\"\n        # If we found a secret, it should be either basic-auth or\
+          \ ssh-auth\n        if secret:\n            secret_data = secret.get(\"\
+          data\", {})\n            secret_type = secret.get(\"type\", \"\")\n    \
+          \        # Required Fields for each type: https://kubernetes.io/docs/concepts/configuration/secret/#basic-authentication-secret\n\
+          \            if secret_type == \"kubernetes.io/basic-auth\":\n         \
+          \       # Even though these are listed as required, you can create a k8s\
+          \ basic-auth secret without\n                # these fields present\n  \
+          \              if \"username\" not in secret_data:\n                   \
+          \ raise RuntimeError(\n                        f\"Taxonomy secret '{taxonomy_repo_secret}'\
+          \ missing required field 'username'\"\n                    )\n         \
+          \       if \"password\" not in secret_data:\n                    raise RuntimeError(\n\
+          \                        f\"Taxonomy secret '{taxonomy_repo_secret}' missing\
+          \ required field 'password'\"\n                    )\n                username\
+          \ = base64.b64decode(secret_data[\"username\"]).decode()\n             \
+          \   token = base64.b64decode(secret_data[\"password\"]).decode()\n     \
+          \       elif secret_type == \"kubernetes.io/ssh-auth\":\n              \
+          \  if \"ssh-privatekey\" not in secret_data:\n                    raise\
+          \ RuntimeError(\n                        f\"Taxonomy secret '{taxonomy_repo_secret}'\
+          \ missing required field 'ssh-privatekey'\"\n                    )\n   \
+          \             ssh_key = base64.b64decode(secret_data[\"ssh-privatekey\"\
+          ]).decode()\n            else:\n                raise RuntimeError(\n  \
+          \                  f\"Only basic-auth or ssh-auth secret types are supported,\
+          \ got type: {secret_type}\"\n                )\n\n        if username or\
+          \ ssh_key:\n            print(\"SDG repo secret data retrieved.\")\n   \
+          \     else:\n            print(\n                \"SDG repo secret content\
+          \ not available. Assuming the default pipeline parameter is unused.\"\n\
+          \            )\n\n    # Whether not provided via env or secret\n    # Assume\
+          \ the repo is public\n    if not username and not ssh_key:\n        print(\"\
+          No credentials provided for taxonomy repo, assuming public repo...\")\n\n\
+          \    ssl_cert_dir = os.getenv(\"SSL_CERT_DIR\")\n    ssl_cert_file = os.getenv(\"\
+          SSL_CERT_FILE\")\n    env = os.environ.copy()\n\n    # Set custom CA certificate\
+          \ if provided\n    # Consume this in the process execution environment\n\
+          \    # This is required for read_taxonomy calls which\n    # Perform nested\
+          \ calls to git clones.\n    if ssl_cert_dir and os.path.exists(ssl_cert_dir):\n\
+          \        print(f\"CA detected at {ssl_cert_dir}\")\n        env[\"GIT_SSL_CAPATH\"\
+          ] = ssl_cert_dir\n        os.environ[\"GIT_SSL_CAPATH\"] = ssl_cert_dir\n\
+          \    elif ssl_cert_file and os.path.exists(ssl_cert_file):\n        print(f\"\
+          CA detected at {ssl_cert_file}\")\n        env[\"GIT_SSL_CAINFO\"] = ssl_cert_file\n\
+          \        os.environ[\"GIT_SSL_CAINFO\"] = ssl_cert_file\n    else:\n   \
+          \     print(\"No CA detected. Using the CA bundle in the container image.\"\
+          )\n\n    git_credentials_path = \"\"\n    ssh_key_path = \"\"\n    # Username/PAT\
+          \ takes precedence over ssh\n    if username and token:\n        print(\"\
+          Configuring Git Credentials...\")\n        # Parse the domain from the repository\
+          \ URL\n        parsed_url = urllib.parse.urlparse(repo_url)\n        git_server\
+          \ = parsed_url.netloc\n\n        # Set up Git credential helper\n      \
+          \  exec_cmd([\"git\", \"config\", \"--global\", \"credential.helper\", \"\
+          store\"], env=env)\n\n        # Save credentials dynamically for any Git\
+          \ server\n        git_credentials_directory = os.path.expanduser(\"~/.git\"\
+          )\n        # Ensure the ~/.git directory exists\n        os.makedirs(git_credentials_directory,\
           \ mode=0o700, exist_ok=True)\n\n        git_credentials_path = f\"{git_credentials_directory}/.git-credentials\"\
           \n        with open(git_credentials_path, \"w\") as f:\n            f.write(f\"\
           https://{username}:{token}@{git_server}\\n\")\n\n        os.chmod(git_credentials_path,\
@@ -1920,14 +1940,19 @@ deploymentSpec:
           \    if sdg_secret_name is None:\n        api_key = os.getenv(\"api_key\"\
           )\n        model_name = os.getenv(\"model_name\")\n        endpoint = os.getenv(\"\
           endpoint\")\n    else:\n        print(\"SDG Teacher secret specified, fetching...\"\
-          )\n        api_key, model_name, endpoint = fetch_secret(\n            sdg_secret_name,\
-          \ [\"api_token\", \"model_name\", \"endpoint\"]\n        )\n        if endpoint\
-          \ is None or model_name is None:\n            print(\n                f\"\
-          The SDG secret {sdg_secret_name} requires at least data.model_name and data.endpoint\"\
-          ,\n                file=sys.stderr,\n            )\n            sys.exit(1)\n\
-          \n        print(\"SDG Teacher secret data retrieved.\")\n\n    # A hack\
-          \ because InstructLab assumes the value for model_name is a valid path and\
-          \ the name of the model.\n    tmp_model_path = os.path.join(tempfile.gettempdir(),\
+          )\n        secret = fetch_secret(\n            sdg_secret_name,\n      \
+          \  )\n        secret_data = secret.get(\"data\", {})\n        api_key =\
+          \ (\n            base64.b64decode(secret_data[\"api_token\"]).decode()\n\
+          \            if \"api_token\" in secret_data\n            else \"\"\n  \
+          \      )\n        model_name = base64.b64decode(secret_data.get(\"model_name\"\
+          , \"\")).decode()\n        endpoint = base64.b64decode(secret_data.get(\"\
+          endpoint\", \"\")).decode()\n        if not endpoint or not model_name:\n\
+          \            print(\n                f\"The SDG secret {sdg_secret_name}\
+          \ requires at least data.model_name and data.endpoint\",\n             \
+          \   file=sys.stderr,\n            )\n            sys.exit(1)\n\n       \
+          \ print(\"SDG Teacher secret data retrieved.\")\n\n    # A hack because\
+          \ InstructLab assumes the value for model_name is a valid path and the name\
+          \ of the model.\n    tmp_model_path = os.path.join(tempfile.gettempdir(),\
           \ model_name)\n    # Since a model name can have a slash in it and InstructLab\
           \ expects this to be a valid path as well, we must\n    # pretend the slashes\
           \ represent directories.\n    if \"/\" in model_name:\n        os.makedirs(os.path.dirname(tmp_model_path),\


### PR DESCRIPTION
## Description
Support basic auth and ssh secret types. This is an api breaking change as we're no longer supporting the old secret keys for taxonomy secret.


Tested with:

Secrets of format:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: secret-ssh-auth
type: kubernetes.io/ssh-auth
data:

  ssh-privatekey: |
    ...
```

and:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: secret-basic-auth
type: kubernetes.io/basic-auth
stringData:
  username: ...
  password: ...
```


Tested against private repo via user/pass and ssh, as well as teacher model connections. 
