### PR TITLE
Update the default memory per work

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -81,7 +81,7 @@ def ilab_pipeline(
     train_gpu_identifier: str = "nvidia.com/gpu",
     train_gpu_per_worker: int = 2,  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
     train_cpu_per_worker: str = "2",  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
-    train_memory_per_worker: str = "100Gi",  # Default value set after observing the memory requirements when running the pipeline
+    train_memory_per_worker: str = "250Gi",  # Default value set after observing the memory requirements when running the pipeline
     train_num_workers: int = 2,  # FIXME: Not present in default config. Arbitrary value chosen to demonstrate multi-node multi-gpu capabilities. Needs proper reference architecture justification.
     train_num_epochs_phase_1: int = 7,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L364
     train_num_epochs_phase_2: int = 10,  # https://github.com/instructlab/instructlab/blob/v0.21.2/tests/testdata/default_config.yaml#L377
@@ -138,7 +138,7 @@ def ilab_pipeline(
         train_gpu_identifier: Training parameter. The GPU type used for training pods, e.g. nvidia.com/gpu
         train_gpu_per_worker: Training parameter. Number of GPUs per each node/worker to use for training.
         train_cpu_per_worker: Training parameter. Number of CPUs per each node/worker to use for training.
-        train_memory_per_worker: Training parameter. Memory per GPU per each node/worker to use for training. 56Gi or more is recommended
+        train_memory_per_worker: Training parameter. Memory per GPU per each node/worker to use for training. 250Gi or more is recommended
         train_num_workers: Training parameter. Number of nodes/workers to train on.
         train_num_epochs_phase_1: Training parameter for in Phase 1. Number of epochs to run training.
         train_num_epochs_phase_2: Training parameter for in Phase 2. Number of epochs to run training.

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -39,7 +39,7 @@
 #    train_learning_rate_phase_1: float [Default: 2e-05]
 #    train_learning_rate_phase_2: float [Default: 6e-06]
 #    train_max_batch_len: int [Default: 5000.0]
-#    train_memory_per_worker: str [Default: '100Gi']
+#    train_memory_per_worker: str [Default: '250Gi']
 #    train_node_selectors: dict
 #    train_num_epochs_phase_1: int [Default: 7.0]
 #    train_num_epochs_phase_2: int [Default: 10.0]
@@ -3342,9 +3342,9 @@ root:
         isOptional: true
         parameterType: NUMBER_INTEGER
       train_memory_per_worker:
-        defaultValue: 100Gi
+        defaultValue: 250Gi
         description: Training parameter. Memory per GPU per each node/worker to use
-          for training. 56Gi or more is recommended
+          for training. 250Gi or more is recommended
         isOptional: true
         parameterType: STRING
       train_node_selectors:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The memory recommendations have increased after updating to RHEL AI 1.5.

Relates:
https://issues.redhat.com/browse/RHOAIENG-26464

## How Has This Been Tested?

A pipeline was run with higher memory and we saw it needed roughly 250 GB of memory.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Increased the default memory allocation per GPU worker for training from 100Gi to 250Gi. This provides more resources for training tasks by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->